### PR TITLE
Day1: Backend bootstrap (health + local postgres + tests)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Postgres (local)
+POSTGRES_DB=jira_lite
+POSTGRES_USER=jira_lite
+POSTGRES_PASSWORD=change_me
+POSTGRES_PORT=5432
+
+# Spring (local)
+SERVER_PORT=8080

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Local env files
+.env
+
+# Build outputs
+target/
+

--- a/.idea/copilot.data.migration.agent.xml
+++ b/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.ask.xml
+++ b/.idea/copilot.data.migration.ask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AskMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.edit.xml
+++ b/.idea/copilot.data.migration.edit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EditMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-<<<<<<< HEAD
-# jira-lite
-Fullstack project
-=======
 # Jira Lite
 
 Multi-tenant ticket system (portfolio project) for AU junior backend/full-stack roles.
 
 ## Tech Stack
+
 - Backend: Java 17, Spring Boot 3, Spring Security, JPA/Hibernate, Flyway, OpenAPI
 - Frontend: React + TypeScript, React Router, React Query, MUI
 - AWS: Cognito, S3 (pre-signed), RDS Postgres, ECS Fargate, ALB, CloudWatch, ECR, CloudFront + S3
@@ -14,5 +11,50 @@ Multi-tenant ticket system (portfolio project) for AU junior backend/full-stack 
 - CI/CD: GitHub Actions
 
 ## Workflow
+
 Issues → Branch → PR → Review → Merge
->>>>>>> 6ba993a (chore: bootstrap repo structure and docs skeleton)
+
+## Local Development (Day 1)
+
+### Prerequisitess
+
+- Docker Desktop
+- Java 17
+
+### 1 Start Postgres
+
+Copy `.env.example` to `.env` and adjust values if needed.
+
+```bash
+cp .env.example .env
+docker compose up -d
+docker ps
+```
+
+### 2 Run Backend (local profile)
+
+```bash
+# Windows
+.\mvnw.cmd --% spring-boot:run -Dspring-boot.run.profiles=local
+```
+
+### 3 Verify health
+
+```bash
+curl.exe -i http://localhost:8080/health
+```
+
+Expected: HTTP 200 and a JSON body containing `"status":"UP"`.
+
+### 4 Run tests
+
+```bash
+./mvnw test
+```
+
+### Reset local DB (clean slate)
+
+```bash
+docker compose down -v
+docker compose up -d
+```

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -61,6 +61,11 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/backend/src/main/java/com/jiralite/backend/controller/HealthController.java
+++ b/backend/src/main/java/com/jiralite/backend/controller/HealthController.java
@@ -1,0 +1,25 @@
+package com.jiralite.backend.controller;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Minimal health endpoint for local/dev verification.
+ */
+@RestController
+public class HealthController {
+
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, Object>> health() {
+        return ResponseEntity.ok(
+            Map.of(
+                "status", "UP",
+                "timestamp", OffsetDateTime.now().toString()
+            )
+        );
+    }
+}
+

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:${POSTGRES_PORT:5432}/${POSTGRES_DB:jira_lite} # postgres url
+    username: ${POSTGRES_USER:jira_lite} # postgres username
+    password: ${POSTGRES_PASSWORD:jira_lite_password} # postgres password
+    driver-class-name: org.postgresql.Driver # postgres driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none # disable ddl auto
+    open-in-view: false # open in view is false by default
+    properties:
+      hibernate:
+        format_sql: true # format sql
+
+  flyway:
+    enabled: true # enable flyway
+    locations: classpath:db/migration # flyway locations  (db/migration is the default location)
+    baseline-on-migrate: true # baseline on migrate
+
+logging:
+  level:
+    org.flywaydb: INFO # flyway level
+    org.hibernate.SQL: INFO # hibernate sql level

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=backend

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: jira-lite # spring project name
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false # write dates as timestamps
+
+server:
+  port: ${SERVER_PORT:8080} # server port
+# Note:
+# - Do not hardcode local DB settings here.
+# - Use profile "local" to run with local Postgres.
+

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,134 @@
+-- V1: Initial schema for Jira Lite (multi-tenant)
+-- Rules:
+-- - Tenant-owned tables include org_id.
+-- - Composite foreign keys (org_id, id) prevent cross-org references.
+
+BEGIN;
+
+-- For gen_random_uuid()
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Orgs
+CREATE TABLE IF NOT EXISTS orgs (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Users (global)
+CREATE TABLE IF NOT EXISTS users (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email        TEXT NOT NULL UNIQUE,
+  display_name TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Memberships (RBAC minimal)
+CREATE TABLE IF NOT EXISTS org_memberships (
+  org_id      UUID NOT NULL,
+  user_id     UUID NOT NULL,
+  role        TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (org_id, user_id),
+  CONSTRAINT fk_membership_org FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE,
+  CONSTRAINT fk_membership_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT ck_membership_role CHECK (role IN ('ADMIN', 'MEMBER'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_org_memberships_user_id ON org_memberships(user_id);
+CREATE INDEX IF NOT EXISTS idx_org_memberships_org_id ON org_memberships(org_id);
+
+-- Projects
+CREATE TABLE IF NOT EXISTS projects (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id      UUID NOT NULL,
+  project_key TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT fk_projects_org FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE,
+  CONSTRAINT uq_projects_org_project_key UNIQUE (org_id, project_key),
+  CONSTRAINT uq_projects_org_id_id UNIQUE (org_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_projects_org_id ON projects(org_id);
+
+-- Tickets
+CREATE TABLE IF NOT EXISTS tickets (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id      UUID NOT NULL,
+  project_id  UUID NOT NULL,
+  ticket_key  TEXT NOT NULL,
+  title       TEXT NOT NULL,
+  description TEXT,
+  status      TEXT NOT NULL DEFAULT 'OPEN',
+  priority    TEXT NOT NULL DEFAULT 'MEDIUM',
+  created_by  UUID,
+  assignee_id UUID,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT fk_tickets_org FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE,
+
+  -- Prevent cross-org project reference
+  CONSTRAINT fk_tickets_project FOREIGN KEY (org_id, project_id)
+    REFERENCES projects(org_id, id) ON DELETE RESTRICT,
+
+  CONSTRAINT fk_tickets_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
+  CONSTRAINT fk_tickets_assignee FOREIGN KEY (assignee_id) REFERENCES users(id) ON DELETE SET NULL,
+
+  CONSTRAINT uq_tickets_org_ticket_key UNIQUE (org_id, ticket_key),
+  CONSTRAINT uq_tickets_org_id_id UNIQUE (org_id, id),
+
+  CONSTRAINT ck_tickets_status CHECK (status IN ('OPEN', 'IN_PROGRESS', 'DONE', 'CANCELLED')),
+  CONSTRAINT ck_tickets_priority CHECK (priority IN ('LOW', 'MEDIUM', 'HIGH', 'URGENT'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_tickets_org_id ON tickets(org_id);
+CREATE INDEX IF NOT EXISTS idx_tickets_project_id ON tickets(project_id);
+CREATE INDEX IF NOT EXISTS idx_tickets_status ON tickets(status);
+CREATE INDEX IF NOT EXISTS idx_tickets_created_at ON tickets(created_at);
+
+-- Ticket comments
+CREATE TABLE IF NOT EXISTS ticket_comments (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id      UUID NOT NULL,
+  ticket_id   UUID NOT NULL,
+  author_id   UUID,
+  body        TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT fk_comments_org FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE,
+  CONSTRAINT fk_comments_ticket FOREIGN KEY (org_id, ticket_id)
+    REFERENCES tickets(org_id, id) ON DELETE CASCADE,
+  CONSTRAINT fk_comments_author FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_comments_org_id ON ticket_comments(org_id);
+CREATE INDEX IF NOT EXISTS idx_ticket_comments_ticket_id ON ticket_comments(ticket_id);
+
+-- Ticket attachments
+CREATE TABLE IF NOT EXISTS ticket_attachments (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id        UUID NOT NULL,
+  ticket_id     UUID NOT NULL,
+  uploaded_by   UUID,
+  file_name     TEXT NOT NULL,
+  content_type  TEXT NOT NULL,
+  file_size     BIGINT NOT NULL DEFAULT 0,
+  s3_key        TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT fk_attachments_org FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE,
+  CONSTRAINT fk_attachments_ticket FOREIGN KEY (org_id, ticket_id)
+    REFERENCES tickets(org_id, id) ON DELETE CASCADE,
+  CONSTRAINT fk_attachments_uploader FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_attachments_org_id ON ticket_attachments(org_id);
+CREATE INDEX IF NOT EXISTS idx_ticket_attachments_ticket_id ON ticket_attachments(ticket_id);
+
+COMMIT;
+

--- a/backend/src/test/java/com/jiralite/backend/SmokeTest.java
+++ b/backend/src/test/java/com/jiralite/backend/SmokeTest.java
@@ -1,0 +1,17 @@
+package com.jiralite.backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Minimal smoke test to ensure application context loads.
+ */
+@SpringBootTest
+class SmokeTest {
+
+    @Test
+    void contextLoads() {
+        // no-op
+    }
+}
+

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  flyway:
+    enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: none

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: jira_lite_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-jira_lite} # postgres database
+      POSTGRES_USER: ${POSTGRES_USER:-jira_lite} # postgres username
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-jira_lite_password} # postgres password
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432" # postgres port
+    volumes:
+      - jira_lite_pg_data:/var/lib/postgresql/data # postgres data volume
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-jira_lite} -d ${POSTGRES_DB:-jira_lite}"] # postgres healthcheck
+      interval: 5s # healthcheck interval
+      timeout: 3s # healthcheck timeout
+      retries: 20 # healthcheck retries
+
+volumes:
+  jira_lite_pg_data: # postgres data volume

--- a/docs/ai/prompt-log.md
+++ b/docs/ai/prompt-log.md
@@ -14,3 +14,27 @@ Outputs:
 - .github/pull_request_template.md
   Validation:
 - Files created under repo root and committed to Git
+
+## 2026-01-12 (Day 1)
+
+- Tool: Cursor / Claude Code
+- Prompt Summary: Generate Day1 local dev loop files (docker-compose, local config, Flyway V1, /health, docs).
+- Adopted Output: Created/updated all listed files; adjusted Java package to match project base package.
+- Files Changed:
+  - docker-compose.yml
+  - .env.example
+  - .gitignore
+  - backend/src/main/resources/application.yml
+  - backend/src/main/resources/application-local.yml
+  - backend/src/main/resources/db/migration/V1__init.sql
+  - backend/src/main/java/.../controller/HealthController.java
+  - backend/src/test/java/.../SmokeTest.java
+  - docs/runbooks/local-dev.md
+  - docs/design/db-schema.md
+  - README.md
+- Verification:
+  - cp .env.example .env
+  - docker compose up -d
+  - ./mvnw spring-boot:run -Dspring-boot.run.profiles=local
+  - curl -i http://localhost:8080/health
+  - ./mvnw test

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,0 +1,13 @@
+## Architecture
+
+```mermaid
+flowchart LR
+  U[User] --> CF[CloudFront]
+  CF --> S3FE[S3 Frontend]
+  CF --> ALB[ALB]
+  ALB --> ECS[ECS Fargate - Spring Boot]
+  ECS --> RDS[(RDS Postgres)]
+  ECS --> S3AT[S3 Attachments]
+  ECS --> CW[CloudWatch Logs]
+  U --> COG[Cognito]
+  ECS --> COG

--- a/docs/design/db-schema.md
+++ b/docs/design/db-schema.md
@@ -1,0 +1,19 @@
+# Database Schema (MVP)
+
+## Goals
+- Multi-tenant isolation via `org_id` on tenant-owned tables
+- Prevent cross-org references using composite FKs `(org_id, id)`
+- Minimal RBAC via `org_memberships.role`: `ADMIN`, `MEMBER`
+
+## ERD
+```mermaid
+erDiagram
+  ORGS ||--o{ ORG_MEMBERSHIPS : has
+  USERS ||--o{ ORG_MEMBERSHIPS : has
+  ORGS ||--o{ PROJECTS : owns
+  PROJECTS ||--o{ TICKETS : contains
+  TICKETS ||--o{ TICKET_COMMENTS : has
+  TICKETS ||--o{ TICKET_ATTACHMENTS : has
+```
+
+

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -1,0 +1,54 @@
+# Local Dev Runbook
+
+## Commands
+
+### Start DB
+
+```bash
+docker compose up -d
+docker ps
+docker logs -f jira_lite_postgres
+```
+
+### Stop DB
+
+```bash
+docker compose down
+```
+
+### Reset DB (drop volumes)
+
+```bash
+docker compose down -v
+docker compose up -d
+```
+
+### Run backend with local profile
+
+```bash
+.\mvnw.cmd --% spring-boot:run -Dspring-boot.run.profiles=local
+```
+
+### Verify health
+
+```bash
+curl.exe -i http://localhost:8080/health
+```
+
+## Troubleshooting
+
+### Port 5432 is already in use
+
+- Change `POSTGRES_PORT` in `.env`
+- Or stop existing local Postgres service
+
+### Backend cannot connect to DB
+
+- Check container: `docker ps`
+- Check logs: `docker logs jira_lite_postgres`
+- Confirm `.env` values match `application-local.yml`
+
+### Flyway migration fails
+
+- Read SQL error in backend logs
+- Reset DB with `docker compose down -v` then retry


### PR DESCRIPTION
## What
Bootstrapped the backend for local development with Postgres + Flyway (via local profile).
Added a health check endpoint GET /health returning service status.
Stabilised test execution by disabling Flyway in test runtime (H2 does not support Postgres-only SQL like CREATE EXTENSION).

## Why
We need a reliable local runtime environment to start implementing real features on top of a working database schema.
A /health endpoint provides a fast way to verify the service is running (useful for manual checks, CI smoke checks, and future container orchestration).
./mvnw test was failing because tests default to H2, while Flyway migrations contain Postgres-specific statements (e.g. CREATE EXTENSION pgcrypto). Disabling Flyway in tests avoids false failures and keeps tests fast and deterministic.

## How
Local runtime uses application-local.yml to connect to Postgres and run Flyway migrations (classpath:db/migration).
Test runtime uses src/test/resources/application.yml to override settings:
spring.flyway.enabled=false to skip migrations under H2
spring.jpa.hibernate.ddl-auto=none to avoid schema auto-generation
Health endpoint returns a simple JSON payload with timestamp + status.

## Testing
1.Manual verification：
Started backend with local profile:
  cd backend
  .\mvnw.cmd --% spring-boot:run -Dspring-boot.run.profiles=local
Verified endpoint:
  curl.exe -i http://localhost:8080/health → 200 {"status":"UP", ...}

2.Unit tests：
cd backend
.\mvnw.cmd test → BUILD SUCCESS

