### PR TITLE
feat(day7): tickets CRUD, status flow, and docs

### DIFF
--- a/backend/src/main/java/com/jiralite/backend/controller/TicketsController.java
+++ b/backend/src/main/java/com/jiralite/backend/controller/TicketsController.java
@@ -1,0 +1,88 @@
+package com.jiralite.backend.controller;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jiralite.backend.dto.CreateTicketRequest;
+import com.jiralite.backend.dto.PagedResponse;
+import com.jiralite.backend.dto.TicketResponse;
+import com.jiralite.backend.dto.TransitionTicketRequest;
+import com.jiralite.backend.dto.UpdateTicketRequest;
+import com.jiralite.backend.service.TicketService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+/**
+ * Ticket endpoints scoped to the current org.
+ */
+@RestController
+@RequestMapping("/tickets")
+@Tag(name = "Tickets", description = "Ticket management within current org")
+@Validated
+public class TicketsController {
+
+    private final TicketService ticketService;
+
+    public TicketsController(TicketService ticketService) {
+        this.ticketService = ticketService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "List tickets in current org (paged)")
+    public ResponseEntity<PagedResponse<TicketResponse>> listTickets(
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String priority,
+            @RequestParam(required = false) UUID projectId,
+            Pageable pageable) {
+        return ResponseEntity.ok(ticketService.listTickets(status, priority, projectId, pageable));
+    }
+
+    @GetMapping("/{ticketId}")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Get ticket detail in current org")
+    public ResponseEntity<TicketResponse> getTicket(@PathVariable UUID ticketId) {
+        return ResponseEntity.ok(ticketService.getTicket(ticketId));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Create ticket in current org")
+    public ResponseEntity<TicketResponse> createTicket(@Valid @RequestBody CreateTicketRequest request) {
+        TicketResponse response = ticketService.createTicket(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PatchMapping("/{ticketId}")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Update ticket in current org")
+    public ResponseEntity<TicketResponse> updateTicket(
+            @PathVariable UUID ticketId,
+            @Valid @RequestBody UpdateTicketRequest request) {
+        return ResponseEntity.ok(ticketService.updateTicket(ticketId, request));
+    }
+
+    @PostMapping("/{ticketId}/transition")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Transition ticket status in current org")
+    public ResponseEntity<TicketResponse> transitionTicket(
+            @PathVariable UUID ticketId,
+            @Valid @RequestBody TransitionTicketRequest request) {
+        return ResponseEntity.ok(ticketService.transition(ticketId, request));
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/CreateTicketRequest.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/CreateTicketRequest.java
@@ -1,0 +1,62 @@
+package com.jiralite.backend.dto;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class CreateTicketRequest {
+
+    @NotNull
+    private UUID projectId;
+
+    @NotBlank
+    private String title;
+
+    private String description;
+
+    @NotBlank
+    private String priority;
+
+    private UUID assigneeId;
+
+    public UUID getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(UUID projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
+
+    public UUID getAssigneeId() {
+        return assigneeId;
+    }
+
+    public void setAssigneeId(UUID assigneeId) {
+        this.assigneeId = assigneeId;
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/PageMeta.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/PageMeta.java
@@ -1,0 +1,9 @@
+package com.jiralite.backend.dto;
+
+public record PageMeta(
+        int number,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/PagedResponse.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/PagedResponse.java
@@ -1,0 +1,9 @@
+package com.jiralite.backend.dto;
+
+import java.util.List;
+
+public record PagedResponse<T>(
+        List<T> content,
+        PageMeta page
+) {
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/TicketResponse.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/TicketResponse.java
@@ -1,0 +1,18 @@
+package com.jiralite.backend.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record TicketResponse(
+        UUID id,
+        UUID projectId,
+        String key,
+        String title,
+        String description,
+        String status,
+        String priority,
+        UUID assigneeId,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/TransitionTicketRequest.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/TransitionTicketRequest.java
@@ -1,0 +1,17 @@
+package com.jiralite.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class TransitionTicketRequest {
+
+    @NotBlank
+    private String status;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/UpdateTicketRequest.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/UpdateTicketRequest.java
@@ -1,0 +1,46 @@
+package com.jiralite.backend.dto;
+
+import java.util.UUID;
+
+public class UpdateTicketRequest {
+
+    private String title;
+
+    private String description;
+
+    private String priority;
+
+    private UUID assigneeId;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
+
+    public UUID getAssigneeId() {
+        return assigneeId;
+    }
+
+    public void setAssigneeId(UUID assigneeId) {
+        this.assigneeId = assigneeId;
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/entity/TicketEntity.java
+++ b/backend/src/main/java/com/jiralite/backend/entity/TicketEntity.java
@@ -1,0 +1,149 @@
+package com.jiralite.backend.entity;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Ticket entity scoped to a tenant org and project.
+ */
+@Entity
+@Table(name = "tickets")
+public class TicketEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "org_id", nullable = false)
+    private UUID orgId;
+
+    @Column(name = "project_id", nullable = false)
+    private UUID projectId;
+
+    @Column(name = "ticket_key", nullable = false)
+    private String ticketKey;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column
+    private String description;
+
+    @Column(nullable = false)
+    private String status;
+
+    @Column(nullable = false)
+    private String priority;
+
+    @Column(name = "created_by")
+    private UUID createdBy;
+
+    @Column(name = "assignee_id")
+    private UUID assigneeId;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(UUID orgId) {
+        this.orgId = orgId;
+    }
+
+    public UUID getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(UUID projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getTicketKey() {
+        return ticketKey;
+    }
+
+    public void setTicketKey(String ticketKey) {
+        this.ticketKey = ticketKey;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
+
+    public UUID getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(UUID createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public UUID getAssigneeId() {
+        return assigneeId;
+    }
+
+    public void setAssigneeId(UUID assigneeId) {
+        this.assigneeId = assigneeId;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(OffsetDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/repository/TicketRepository.java
+++ b/backend/src/main/java/com/jiralite/backend/repository/TicketRepository.java
@@ -1,0 +1,15 @@
+package com.jiralite.backend.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import com.jiralite.backend.entity.TicketEntity;
+
+public interface TicketRepository extends JpaRepository<TicketEntity, UUID>, JpaSpecificationExecutor<TicketEntity> {
+    Optional<TicketEntity> findByIdAndOrgId(UUID id, UUID orgId);
+
+    long countByOrgIdAndProjectId(UUID orgId, UUID projectId);
+}

--- a/backend/src/main/java/com/jiralite/backend/service/TicketService.java
+++ b/backend/src/main/java/com/jiralite/backend/service/TicketService.java
@@ -1,0 +1,284 @@
+package com.jiralite.backend.service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jiralite.backend.dto.CreateTicketRequest;
+import com.jiralite.backend.dto.ErrorCode;
+import com.jiralite.backend.dto.PageMeta;
+import com.jiralite.backend.dto.PagedResponse;
+import com.jiralite.backend.dto.TicketResponse;
+import com.jiralite.backend.dto.TransitionTicketRequest;
+import com.jiralite.backend.dto.UpdateTicketRequest;
+import com.jiralite.backend.entity.OrgMembershipEntity;
+import com.jiralite.backend.entity.ProjectEntity;
+import com.jiralite.backend.entity.TicketEntity;
+import com.jiralite.backend.exception.ApiException;
+import com.jiralite.backend.repository.OrgMembershipRepository;
+import com.jiralite.backend.repository.ProjectRepository;
+import com.jiralite.backend.repository.TicketRepository;
+import com.jiralite.backend.security.tenant.TenantContext;
+import com.jiralite.backend.security.tenant.TenantContextHolder;
+
+/**
+ * Ticket management scoped to the current tenant.
+ */
+@Service
+public class TicketService {
+
+    private static final Set<String> ALLOWED_STATUSES = Set.of("OPEN", "IN_PROGRESS", "DONE", "CANCELLED");
+    private static final Set<String> ALLOWED_PRIORITIES = Set.of("LOW", "MEDIUM", "HIGH", "URGENT");
+
+    private final TicketRepository ticketRepository;
+    private final ProjectRepository projectRepository;
+    private final OrgMembershipRepository membershipRepository;
+
+    public TicketService(
+            TicketRepository ticketRepository,
+            ProjectRepository projectRepository,
+            OrgMembershipRepository membershipRepository) {
+        this.ticketRepository = ticketRepository;
+        this.projectRepository = projectRepository;
+        this.membershipRepository = membershipRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<TicketResponse> listTickets(
+            String status,
+            String priority,
+            UUID projectId,
+            Pageable pageable) {
+        UUID orgId = getOrgId();
+        Specification<TicketEntity> spec = (root, query, cb) -> cb.conjunction();
+        spec = spec.and(orgEquals(orgId));
+        Specification<TicketEntity> statusSpec = statusEquals(status);
+        if (statusSpec != null) {
+            spec = spec.and(statusSpec);
+        }
+        Specification<TicketEntity> prioritySpec = priorityEquals(priority);
+        if (prioritySpec != null) {
+            spec = spec.and(prioritySpec);
+        }
+        Specification<TicketEntity> projectSpec = projectEquals(projectId);
+        if (projectSpec != null) {
+            spec = spec.and(projectSpec);
+        }
+
+        Page<TicketEntity> page = ticketRepository.findAll(spec, pageable);
+        List<TicketResponse> content = page.stream()
+                .map(this::toResponse)
+                .toList();
+        return new PagedResponse<>(
+                content,
+                new PageMeta(page.getNumber(), page.getSize(), page.getTotalElements(), page.getTotalPages()));
+    }
+
+    @Transactional(readOnly = true)
+    public TicketResponse getTicket(UUID ticketId) {
+        return toResponse(findTicket(ticketId));
+    }
+
+    @Transactional
+    public TicketResponse createTicket(CreateTicketRequest request) {
+        UUID orgId = getOrgId();
+        ProjectEntity project = projectRepository.findByIdAndOrgId(request.getProjectId(), orgId)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "Project not found",
+                        HttpStatus.NOT_FOUND.value()));
+
+        String priority = normalizePriority(request.getPriority());
+        validateAssignee(orgId, request.getAssigneeId());
+
+        long nextNumber = ticketRepository.countByOrgIdAndProjectId(orgId, project.getId()) + 1;
+        String ticketKey = project.getProjectKey() + "-" + nextNumber;
+
+        OffsetDateTime now = OffsetDateTime.now();
+        TicketEntity ticket = new TicketEntity();
+        ticket.setId(UUID.randomUUID());
+        ticket.setOrgId(orgId);
+        ticket.setProjectId(project.getId());
+        ticket.setTicketKey(ticketKey);
+        ticket.setTitle(request.getTitle());
+        ticket.setDescription(request.getDescription());
+        ticket.setStatus("OPEN");
+        ticket.setPriority(priority);
+        ticket.setCreatedBy(parseUuidOrNull(getUserId()));
+        ticket.setAssigneeId(request.getAssigneeId());
+        ticket.setCreatedAt(now);
+        ticket.setUpdatedAt(now);
+
+        TicketEntity saved = ticketRepository.save(ticket);
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public TicketResponse updateTicket(UUID ticketId, UpdateTicketRequest request) {
+        if ((request.getTitle() == null || request.getTitle().isBlank())
+                && request.getDescription() == null
+                && (request.getPriority() == null || request.getPriority().isBlank())
+                && request.getAssigneeId() == null) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "No fields to update", HttpStatus.BAD_REQUEST.value());
+        }
+
+        TicketEntity ticket = findTicket(ticketId);
+        if (request.getTitle() != null && !request.getTitle().isBlank()) {
+            ticket.setTitle(request.getTitle());
+        }
+        if (request.getDescription() != null) {
+            ticket.setDescription(request.getDescription());
+        }
+        if (request.getPriority() != null && !request.getPriority().isBlank()) {
+            ticket.setPriority(normalizePriority(request.getPriority()));
+        }
+        if (request.getAssigneeId() != null) {
+            validateAssignee(ticket.getOrgId(), request.getAssigneeId());
+            ticket.setAssigneeId(request.getAssigneeId());
+        }
+        ticket.setUpdatedAt(OffsetDateTime.now());
+
+        return toResponse(ticket);
+    }
+
+    @Transactional
+    public TicketResponse transition(UUID ticketId, TransitionTicketRequest request) {
+        TicketEntity ticket = findTicket(ticketId);
+        String nextStatus = normalizeStatus(request.getStatus());
+        if (!isValidTransition(ticket.getStatus(), nextStatus)) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "Invalid status transition", HttpStatus.BAD_REQUEST.value());
+        }
+        ticket.setStatus(nextStatus);
+        ticket.setUpdatedAt(OffsetDateTime.now());
+        return toResponse(ticket);
+    }
+
+    private TicketEntity findTicket(UUID ticketId) {
+        UUID orgId = getOrgId();
+        return ticketRepository.findByIdAndOrgId(ticketId, orgId)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "Ticket not found",
+                        HttpStatus.NOT_FOUND.value()));
+    }
+
+    private UUID getOrgId() {
+        TenantContext context = TenantContextHolder.getRequired();
+        if (context.orgId() == null || context.orgId().isBlank()) {
+            throw new ApiException(ErrorCode.UNAUTHORIZED, "Missing org context", HttpStatus.UNAUTHORIZED.value());
+        }
+        return UUID.fromString(context.orgId());
+    }
+
+    private String getUserId() {
+        TenantContext context = TenantContextHolder.getRequired();
+        return context.userId();
+    }
+
+    private void validateAssignee(UUID orgId, UUID assigneeId) {
+        if (assigneeId == null) {
+            return;
+        }
+        OrgMembershipEntity membership = membershipRepository
+                .findByIdOrgIdAndIdUserId(orgId, assigneeId)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "Assignee not in org",
+                        HttpStatus.NOT_FOUND.value()));
+        if (membership.getStatus() != null && "DISABLED".equalsIgnoreCase(membership.getStatus())) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "Assignee is disabled", HttpStatus.BAD_REQUEST.value());
+        }
+    }
+
+    private String normalizeStatus(String status) {
+        if (status == null || status.isBlank()) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "Status is required", HttpStatus.BAD_REQUEST.value());
+        }
+        String normalized = status.toUpperCase(Locale.ROOT);
+        if (!ALLOWED_STATUSES.contains(normalized)) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "Invalid status", HttpStatus.BAD_REQUEST.value());
+        }
+        return normalized;
+    }
+
+    private String normalizePriority(String priority) {
+        if (priority == null || priority.isBlank()) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "Priority is required", HttpStatus.BAD_REQUEST.value());
+        }
+        String normalized = priority.toUpperCase(Locale.ROOT);
+        if (!ALLOWED_PRIORITIES.contains(normalized)) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "Invalid priority", HttpStatus.BAD_REQUEST.value());
+        }
+        return normalized;
+    }
+
+    private boolean isValidTransition(String current, String next) {
+        if (current == null) {
+            return false;
+        }
+        if (current.equals(next)) {
+            return true;
+        }
+        return switch (current) {
+            case "OPEN" -> next.equals("IN_PROGRESS") || next.equals("DONE") || next.equals("CANCELLED");
+            case "IN_PROGRESS" -> next.equals("DONE") || next.equals("CANCELLED");
+            case "DONE", "CANCELLED" -> false;
+            default -> false;
+        };
+    }
+
+    private Specification<TicketEntity> orgEquals(UUID orgId) {
+        return (root, query, cb) -> cb.equal(root.get("orgId"), orgId);
+    }
+
+    private Specification<TicketEntity> statusEquals(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+        String normalized = status.toUpperCase(Locale.ROOT);
+        return (root, query, cb) -> cb.equal(root.get("status"), normalized);
+    }
+
+    private Specification<TicketEntity> priorityEquals(String priority) {
+        if (priority == null || priority.isBlank()) {
+            return null;
+        }
+        String normalized = priority.toUpperCase(Locale.ROOT);
+        return (root, query, cb) -> cb.equal(root.get("priority"), normalized);
+    }
+
+    private Specification<TicketEntity> projectEquals(UUID projectId) {
+        if (projectId == null) {
+            return null;
+        }
+        return (root, query, cb) -> cb.equal(root.get("projectId"), projectId);
+    }
+
+    private UUID parseUuidOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private TicketResponse toResponse(TicketEntity ticket) {
+        return new TicketResponse(
+                ticket.getId(),
+                ticket.getProjectId(),
+                ticket.getTicketKey(),
+                ticket.getTitle(),
+                ticket.getDescription(),
+                ticket.getStatus(),
+                ticket.getPriority(),
+                ticket.getAssigneeId(),
+                ticket.getCreatedAt(),
+                ticket.getUpdatedAt());
+    }
+}

--- a/backend/src/main/resources/db/migration/V7__tickets_indexes.sql
+++ b/backend/src/main/resources/db/migration/V7__tickets_indexes.sql
@@ -1,0 +1,7 @@
+-- V7: Ticket query optimization for list/filter/sort
+
+CREATE INDEX IF NOT EXISTS idx_tickets_org_status ON tickets(org_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_tickets_org_project ON tickets(org_id, project_id);
+
+CREATE INDEX IF NOT EXISTS idx_tickets_org_created_at ON tickets(org_id, created_at DESC);

--- a/backend/src/test/java/com/jiralite/backend/TicketsIntegrationTest.java
+++ b/backend/src/test/java/com/jiralite/backend/TicketsIntegrationTest.java
@@ -1,0 +1,207 @@
+package com.jiralite.backend;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.jiralite.backend.entity.OrgEntity;
+import com.jiralite.backend.entity.OrgMembershipEntity;
+import com.jiralite.backend.entity.OrgMembershipId;
+import com.jiralite.backend.entity.ProjectEntity;
+import com.jiralite.backend.entity.TicketEntity;
+import com.jiralite.backend.entity.UserEntity;
+import com.jiralite.backend.repository.OrgMembershipRepository;
+import com.jiralite.backend.repository.OrgRepository;
+import com.jiralite.backend.repository.ProjectRepository;
+import com.jiralite.backend.repository.TicketRepository;
+import com.jiralite.backend.repository.UserRepository;
+import com.jiralite.backend.security.TestJwtDecoderConfig;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(TestJwtDecoderConfig.class)
+class TicketsIntegrationTest {
+
+    private static final UUID ORG_1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID ORG_2 = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID PROJECT_1 = UUID.fromString("aaaaaaaa-1111-1111-1111-111111111111");
+    private static final UUID PROJECT_2 = UUID.fromString("bbbbbbbb-2222-2222-2222-222222222222");
+    private static final UUID TICKET_1 = UUID.fromString("cccccccc-3333-3333-3333-333333333333");
+    private static final UUID TICKET_2 = UUID.fromString("dddddddd-4444-4444-4444-444444444444");
+    private static final UUID USER_A = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private OrgRepository orgRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private OrgMembershipRepository membershipRepository;
+
+    @BeforeEach
+    void setUp() {
+        ticketRepository.deleteAll();
+        projectRepository.deleteAll();
+        membershipRepository.deleteAll();
+        userRepository.deleteAll();
+        orgRepository.deleteAll();
+
+        orgRepository.save(org("Org One", ORG_1));
+        orgRepository.save(org("Org Two", ORG_2));
+
+        projectRepository.save(project(PROJECT_1, ORG_1, "JIRA", "Jira Lite"));
+        projectRepository.save(project(PROJECT_2, ORG_2, "OPS", "Ops Portal"));
+
+        userRepository.save(user(USER_A, "user-a@example.com", "User A"));
+        membershipRepository.save(membership(ORG_1, USER_A, "MEMBER", "ACTIVE"));
+
+        ticketRepository.save(ticket(TICKET_1, ORG_1, PROJECT_1, "JIRA-1", "First ticket", "OPEN"));
+        ticketRepository.save(ticket(TICKET_2, ORG_2, PROJECT_2, "OPS-1", "Other org", "OPEN"));
+    }
+
+    @Test
+    void list_requires_authentication() throws Exception {
+        mockMvc.perform(get("/tickets"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.traceId", notNullValue()));
+    }
+
+    @Test
+    void member_lists_only_current_org_tickets() throws Exception {
+        mockMvc.perform(get("/tickets")
+                        .header("Authorization", "Bearer member-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].id").value(TICKET_1.toString()))
+                .andExpect(jsonPath("$.page.totalElements").value(1));
+    }
+
+    @Test
+    void member_cannot_access_other_org_ticket() throws Exception {
+        mockMvc.perform(get("/tickets/{ticketId}", TICKET_2)
+                        .header("Authorization", "Bearer member-token"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.traceId", notNullValue()));
+    }
+
+    @Test
+    void member_can_create_ticket() throws Exception {
+        String payload = "{\"projectId\":\"" + PROJECT_1 + "\",\"title\":\"New ticket\",\"priority\":\"HIGH\"}";
+        mockMvc.perform(post("/tickets")
+                        .header("Authorization", "Bearer member-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.key").value("JIRA-2"))
+                .andExpect(jsonPath("$.status").value("OPEN"));
+    }
+
+    @Test
+    void transition_rejects_invalid_status() throws Exception {
+        String payload = "{\"status\":\"INVALID\"}";
+        mockMvc.perform(post("/tickets/{ticketId}/transition", TICKET_1)
+                        .header("Authorization", "Bearer member-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.traceId", notNullValue()));
+    }
+
+    @Test
+    void transition_allows_open_to_in_progress() throws Exception {
+        String payload = "{\"status\":\"IN_PROGRESS\"}";
+        mockMvc.perform(post("/tickets/{ticketId}/transition", TICKET_1)
+                        .header("Authorization", "Bearer member-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("IN_PROGRESS"));
+    }
+
+    private OrgEntity org(String name, UUID id) {
+        OrgEntity org = new OrgEntity();
+        org.setId(id);
+        org.setName(name);
+        org.setCreatedAt(OffsetDateTime.now());
+        org.setUpdatedAt(OffsetDateTime.now());
+        return org;
+    }
+
+    private ProjectEntity project(UUID id, UUID orgId, String key, String name) {
+        ProjectEntity project = new ProjectEntity();
+        project.setId(id);
+        project.setOrgId(orgId);
+        project.setProjectKey(key);
+        project.setName(name);
+        project.setDescription("Seeded project");
+        project.setStatus("ACTIVE");
+        project.setCreatedAt(OffsetDateTime.now());
+        project.setUpdatedAt(OffsetDateTime.now());
+        return project;
+    }
+
+    private TicketEntity ticket(UUID id, UUID orgId, UUID projectId, String key, String title, String status) {
+        TicketEntity ticket = new TicketEntity();
+        ticket.setId(id);
+        ticket.setOrgId(orgId);
+        ticket.setProjectId(projectId);
+        ticket.setTicketKey(key);
+        ticket.setTitle(title);
+        ticket.setDescription("Seeded ticket");
+        ticket.setStatus(status);
+        ticket.setPriority("MEDIUM");
+        ticket.setCreatedAt(OffsetDateTime.now());
+        ticket.setUpdatedAt(OffsetDateTime.now());
+        return ticket;
+    }
+
+    private UserEntity user(UUID id, String email, String displayName) {
+        UserEntity user = new UserEntity();
+        user.setId(id);
+        user.setEmail(email);
+        user.setDisplayName(displayName);
+        user.setCreatedAt(OffsetDateTime.now());
+        user.setUpdatedAt(OffsetDateTime.now());
+        return user;
+    }
+
+    private OrgMembershipEntity membership(UUID orgId, UUID userId, String role, String status) {
+        OrgMembershipEntity membership = new OrgMembershipEntity();
+        membership.setId(new OrgMembershipId(orgId, userId));
+        membership.setRole(role);
+        membership.setStatus(status);
+        membership.setCreatedAt(OffsetDateTime.now());
+        membership.setUpdatedAt(OffsetDateTime.now());
+        return membership;
+    }
+}

--- a/backend/src/test/java/com/jiralite/backend/TicketsTcIntegrationTest.java
+++ b/backend/src/test/java/com/jiralite/backend/TicketsTcIntegrationTest.java
@@ -1,0 +1,230 @@
+package com.jiralite.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jiralite.backend.entity.OrgEntity;
+import com.jiralite.backend.entity.OrgMembershipEntity;
+import com.jiralite.backend.entity.OrgMembershipId;
+import com.jiralite.backend.entity.ProjectEntity;
+import com.jiralite.backend.entity.TicketEntity;
+import com.jiralite.backend.entity.UserEntity;
+import com.jiralite.backend.repository.OrgMembershipRepository;
+import com.jiralite.backend.repository.OrgRepository;
+import com.jiralite.backend.repository.ProjectRepository;
+import com.jiralite.backend.repository.TicketRepository;
+import com.jiralite.backend.repository.UserRepository;
+import com.jiralite.backend.security.TestJwtDecoderConfig;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(TestJwtDecoderConfig.class)
+@Testcontainers
+@EnabledIfSystemProperty(named = "runTestcontainers", matches = "true")
+class TicketsTcIntegrationTest {
+
+    private static final UUID ORG_1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID ORG_2 = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID PROJECT_1 = UUID.fromString("aaaaaaaa-1111-1111-1111-111111111111");
+    private static final UUID PROJECT_2 = UUID.fromString("bbbbbbbb-2222-2222-2222-222222222222");
+    private static final UUID TICKET_1 = UUID.fromString("cccccccc-3333-3333-3333-333333333333");
+    private static final UUID TICKET_2 = UUID.fromString("dddddddd-4444-4444-4444-444444444444");
+    private static final UUID USER_A = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    @Container
+    private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
+            .withDatabaseName("jira_lite")
+            .withUsername("jira_lite")
+            .withPassword("jira_lite_password");
+
+    @DynamicPropertySource
+    static void configureDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+    }
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private OrgRepository orgRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private OrgMembershipRepository membershipRepository;
+
+    @BeforeEach
+    void setUp() {
+        ticketRepository.deleteAll();
+        projectRepository.deleteAll();
+        membershipRepository.deleteAll();
+        userRepository.deleteAll();
+        orgRepository.deleteAll();
+
+        orgRepository.save(org("Org One", ORG_1));
+        orgRepository.save(org("Org Two", ORG_2));
+
+        projectRepository.save(project(PROJECT_1, ORG_1, "JIRA", "Jira Lite"));
+        projectRepository.save(project(PROJECT_2, ORG_2, "OPS", "Ops Portal"));
+
+        userRepository.save(user(USER_A, "user-a@example.com", "User A"));
+        membershipRepository.save(membership(ORG_1, USER_A, "MEMBER", "ACTIVE"));
+
+        ticketRepository.save(ticket(TICKET_1, ORG_1, PROJECT_1, "JIRA-1", "First ticket", "OPEN"));
+        ticketRepository.save(ticket(TICKET_2, ORG_2, PROJECT_2, "OPS-1", "Other org", "OPEN"));
+    }
+
+    @Test
+    void member_lists_only_current_org_tickets() throws Exception {
+        ResponseEntity<String> response = restTemplate.exchange(
+                url("/tickets?page=0&size=10"),
+                HttpMethod.GET,
+                authEntity("member-token", null),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertThat(body.get("content").size()).isEqualTo(1);
+        assertThat(body.get("content").get(0).get("id").asText()).isEqualTo(TICKET_1.toString());
+    }
+
+    @Test
+    void member_can_create_ticket() throws Exception {
+        String payload = "{\"projectId\":\"" + PROJECT_1 + "\",\"title\":\"New ticket\",\"priority\":\"HIGH\"}";
+        ResponseEntity<String> response = restTemplate.exchange(
+                url("/tickets"),
+                HttpMethod.POST,
+                authEntity("member-token", payload),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertThat(body.get("key").asText()).isEqualTo("JIRA-2");
+        assertThat(body.get("status").asText()).isEqualTo("OPEN");
+    }
+
+    @Test
+    void member_cannot_access_other_org_ticket() throws Exception {
+        ResponseEntity<String> response = restTemplate.exchange(
+                url("/tickets/" + TICKET_2),
+                HttpMethod.GET,
+                authEntity("member-token", null),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertThat(body.get("code").asText()).isEqualTo("NOT_FOUND");
+    }
+
+    private String url(String path) {
+        return "http://localhost:" + port + path;
+    }
+
+    private HttpEntity<String> authEntity(String token, String body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        if (body != null) {
+            headers.setContentType(MediaType.APPLICATION_JSON);
+        }
+        return new HttpEntity<>(body, headers);
+    }
+
+    private OrgEntity org(String name, UUID id) {
+        OrgEntity org = new OrgEntity();
+        org.setId(id);
+        org.setName(name);
+        org.setCreatedAt(OffsetDateTime.now());
+        org.setUpdatedAt(OffsetDateTime.now());
+        return org;
+    }
+
+    private ProjectEntity project(UUID id, UUID orgId, String key, String name) {
+        ProjectEntity project = new ProjectEntity();
+        project.setId(id);
+        project.setOrgId(orgId);
+        project.setProjectKey(key);
+        project.setName(name);
+        project.setDescription("Seeded project");
+        project.setStatus("ACTIVE");
+        project.setCreatedAt(OffsetDateTime.now());
+        project.setUpdatedAt(OffsetDateTime.now());
+        return project;
+    }
+
+    private TicketEntity ticket(UUID id, UUID orgId, UUID projectId, String key, String title, String status) {
+        TicketEntity ticket = new TicketEntity();
+        ticket.setId(id);
+        ticket.setOrgId(orgId);
+        ticket.setProjectId(projectId);
+        ticket.setTicketKey(key);
+        ticket.setTitle(title);
+        ticket.setDescription("Seeded ticket");
+        ticket.setStatus(status);
+        ticket.setPriority("MEDIUM");
+        ticket.setCreatedAt(OffsetDateTime.now());
+        ticket.setUpdatedAt(OffsetDateTime.now());
+        return ticket;
+    }
+
+    private UserEntity user(UUID id, String email, String displayName) {
+        UserEntity user = new UserEntity();
+        user.setId(id);
+        user.setEmail(email);
+        user.setDisplayName(displayName);
+        user.setCreatedAt(OffsetDateTime.now());
+        user.setUpdatedAt(OffsetDateTime.now());
+        return user;
+    }
+
+    private OrgMembershipEntity membership(UUID orgId, UUID userId, String role, String status) {
+        OrgMembershipEntity membership = new OrgMembershipEntity();
+        membership.setId(new OrgMembershipId(orgId, userId));
+        membership.setRole(role);
+        membership.setStatus(status);
+        membership.setCreatedAt(OffsetDateTime.now());
+        membership.setUpdatedAt(OffsetDateTime.now());
+        return membership;
+    }
+}

--- a/docs/adr/ADR-0007-tickets-crud-and-status-flow.md
+++ b/docs/adr/ADR-0007-tickets-crud-and-status-flow.md
@@ -1,0 +1,25 @@
+# ADR-0007: Tickets CRUD and Status Flow
+
+## Status
+
+Accepted
+
+## Context
+
+The project requires a complete Tickets module with list/detail, create/edit,
+and status transitions. All access must be tenant-scoped by orgId derived from
+JWT claims.
+
+## Decision
+
+- Implement ticket list/detail/create/edit/transition endpoints under `/tickets`.
+- Enforce orgId scoping in service/repository queries.
+- Use a simple status flow: OPEN → IN_PROGRESS → DONE, and OPEN/IN_PROGRESS → CANCELLED.
+- Return 404 for cross-org access to prevent data leakage.
+- Provide paged list responses using a unified `content` + `page` structure.
+
+## Consequences
+
+- Ticket creation requires project ownership within the same org.
+- Status transitions are validated and reject invalid changes with 400 errors.
+- Future work: enforce assignee membership rules and add advanced filtering.

--- a/docs/design/multi-tenancy.md
+++ b/docs/design/multi-tenancy.md
@@ -28,6 +28,11 @@ All membership reads and writes must include `orgId` from `TenantContextHolder`.
 Project CRUD is tenant-scoped by orgId from the JWT claim. Services must query
 projects using `orgId` from `TenantContextHolder` and never accept orgId from clients.
 
+## Tickets
+
+Ticket list/detail/create/update/transition must always scope by `orgId` from
+`TenantContextHolder`. Any cross-org access should return 404 to avoid leakage.
+
 ### C4 Context
 
 ```mermaid

--- a/docs/design/openapi.md
+++ b/docs/design/openapi.md
@@ -62,6 +62,13 @@ All endpoints are automatically documented in Swagger UI:
 - **POST** `/projects/{projectId}/archive` (ADMIN only)
 - **POST** `/projects/{projectId}/unarchive` (ADMIN only)
 
+### Tickets
+- **GET** `/tickets` (paged)
+- **GET** `/tickets/{ticketId}`
+- **POST** `/tickets`
+- **PATCH** `/tickets/{ticketId}`
+- **POST** `/tickets/{ticketId}/transition`
+
 ## Swagger Configuration
 
 ### OpenApiConfig

--- a/docs/design/tickets.md
+++ b/docs/design/tickets.md
@@ -1,0 +1,45 @@
+# Tickets Module
+
+## Overview
+
+Tickets represent work items within a project. All access is tenant-scoped by `orgId`
+from `TenantContext`.
+
+## C4 Context
+
+```mermaid
+C4Context
+title tickets-module
+Person(user, "User")
+System(be, "Backend")
+System_Ext(cognito, "AWS Cognito")
+SystemDb(db, "Postgres")
+Rel(user, cognito, "Login")
+Rel(user, be, "Manage tickets")
+Rel(be, cognito, "Validate JWT + org_id")
+Rel(be, db, "Read/write tickets")
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+title ticket-status-transition
+participant U as Member
+participant API as Backend
+participant SEC as Spring Security
+participant TC as TenantContext
+participant SVC as TicketService
+participant DB as Postgres
+
+U->>API: POST /tickets/{id}/transition + JWT
+API->>SEC: Validate JWT
+SEC-->>TC: Authenticated
+TC->>SVC: orgId from TenantContext
+SVC->>DB: Find ticket by orgId + id
+DB-->>SVC: Ticket
+SVC->>SVC: Validate transition rules
+SVC->>DB: Update status
+DB-->>SVC: OK
+SVC-->>API: TicketResponse
+```

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -137,6 +137,35 @@ curl.exe -i -X POST http://localhost:8080/projects/<PROJECT_ID>/archive ^
   -H "Authorization: Bearer <JWT>"
 ```
 
+## Day 7: Tickets CRUD + Status Flow
+
+### Verify Day 7 Tickets
+
+```bash
+# List tickets (paged)
+curl.exe -i -H "Authorization: Bearer <JWT>" ^
+  "http://localhost:8080/tickets?page=0&size=10&sort=createdAt,desc"
+
+# Create ticket
+curl.exe -i -X POST http://localhost:8080/tickets ^
+  -H "Authorization: Bearer <JWT>" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"projectId\":\"<PROJECT_ID>\",\"title\":\"Bug\",\"priority\":\"HIGH\"}"
+
+# Transition ticket status
+curl.exe -i -X POST http://localhost:8080/tickets/<TICKET_ID>/transition ^
+  -H "Authorization: Bearer <JWT>" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"status\":\"IN_PROGRESS\"}"
+```
+
+### Verify Day 7 Testcontainers (optional)
+
+```bash
+cd backend
+./mvnw test -Dtest=TicketsTcIntegrationTest -DrunTestcontainers=true
+```
+
 ## Troubleshooting
 
 ### Port 5432 is already in use


### PR DESCRIPTION
## What
- Add tickets CRUD + status transition endpoints (tenant-scoped)
- Add pagination/filtering response shape for list
- Add ticket tests + docs/ADR/OpenAPI updates

## Why
- Deliver Day7: tickets module complete with status flow and list filtering

## How
- TicketEntity/Repository/Service/Controller + DTOs
- TenantContext orgId enforced in service + repo queries
- Status flow validated with BAD_REQUEST on invalid transitions

## Testing
- .\mvnw.cmd test
- (Optional) .\mvnw.cmd test -Dtest=TicketsTcIntegrationTest -DrunTestcontainers=true

## Risks
- Testcontainers requires Docker when enabled