### PR TITLE
feat(day8): comments and attachments with presigned URLs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/README.md
+++ b/README.md
@@ -53,9 +53,23 @@ Full local runbook: `docs/runbooks/local-dev.md`
 - Day 2: Error format + traceId + OpenAPI + layering tests
 - Day 3: ERD + Flyway core schema enhancements
 - Day 4: Cognito JWT auth + RBAC + TenantContext
+- Day 5: Org members admin + tenant isolation tests
+- Day 6: Projects CRUD + archive + OpenAPI updates
+- Day 7: Tickets CRUD + pagination/filter/sort + status flow
+- Day 8: Comments + attachments (S3 presigned) + tests/docs
 
 ## Tests
 
 ```bash
-./mvnw test
+# Windows
+.\mvnw.cmd test
+```
+
+Optional Testcontainers (Docker required):
+
+```bash
+.\mvnw.cmd test -Dtest=OrgMembersTcIntegrationTest -DrunTestcontainers=true
+.\mvnw.cmd test -Dtest=TicketsTcIntegrationTest -DrunTestcontainers=true
+.\mvnw.cmd test -Dtest=TicketCommentsTcIntegrationTest -DrunTestcontainers=true
+.\mvnw.cmd test -Dtest=TicketAttachmentsTcIntegrationTest -DrunTestcontainers=true
 ```

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,6 +29,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<testcontainers.version>1.19.8</testcontainers.version>
+		<aws.sdk.version>2.25.32</aws.sdk.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -67,6 +68,11 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.8.9</version>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
+			<version>${aws.sdk.version}</version>
 		</dependency>
 
 		<dependency>

--- a/backend/src/main/java/com/jiralite/backend/config/S3Config.java
+++ b/backend/src/main/java/com/jiralite/backend/config/S3Config.java
@@ -1,0 +1,22 @@
+package com.jiralite.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+/**
+ * S3 presigner configuration for attachment uploads/downloads.
+ */
+@Configuration
+public class S3Config {
+
+    @Bean
+    public S3Presigner s3Presigner(@Value("${app.s3.region}") String region) {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/controller/TicketAttachmentsController.java
+++ b/backend/src/main/java/com/jiralite/backend/controller/TicketAttachmentsController.java
@@ -1,0 +1,77 @@
+package com.jiralite.backend.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jiralite.backend.dto.AttachmentResponse;
+import com.jiralite.backend.dto.PresignDownloadResponse;
+import com.jiralite.backend.dto.PresignUploadRequest;
+import com.jiralite.backend.dto.PresignUploadResponse;
+import com.jiralite.backend.service.TicketAttachmentService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+/**
+ * Ticket attachment endpoints scoped to the current org.
+ */
+@RestController
+@RequestMapping("/tickets/{ticketId}/attachments")
+@Tag(name = "Ticket Attachments", description = "Attachments for tickets")
+@Validated
+public class TicketAttachmentsController {
+
+    private final TicketAttachmentService attachmentService;
+
+    public TicketAttachmentsController(TicketAttachmentService attachmentService) {
+        this.attachmentService = attachmentService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "List attachments for a ticket")
+    public ResponseEntity<List<AttachmentResponse>> listAttachments(@PathVariable UUID ticketId) {
+        return ResponseEntity.ok(attachmentService.listAttachments(ticketId));
+    }
+
+    @PostMapping("/presign-upload")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Presign S3 upload for ticket attachment")
+    public ResponseEntity<PresignUploadResponse> presignUpload(
+            @PathVariable UUID ticketId,
+            @Valid @RequestBody PresignUploadRequest request) {
+        PresignUploadResponse response = attachmentService.presignUpload(ticketId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/{attachmentId}/confirm")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Confirm attachment upload completed")
+    public ResponseEntity<AttachmentResponse> confirmUpload(
+            @PathVariable UUID ticketId,
+            @PathVariable UUID attachmentId) {
+        AttachmentResponse response = attachmentService.confirmUpload(ticketId, attachmentId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{attachmentId}/presign-download")
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Presign S3 download for attachment")
+    public ResponseEntity<PresignDownloadResponse> presignDownload(
+            @PathVariable UUID ticketId,
+            @PathVariable UUID attachmentId) {
+        return ResponseEntity.ok(attachmentService.presignDownload(ticketId, attachmentId));
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/controller/TicketCommentsController.java
+++ b/backend/src/main/java/com/jiralite/backend/controller/TicketCommentsController.java
@@ -1,0 +1,56 @@
+package com.jiralite.backend.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jiralite.backend.dto.CommentResponse;
+import com.jiralite.backend.dto.CreateCommentRequest;
+import com.jiralite.backend.service.TicketCommentService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+/**
+ * Ticket comment endpoints scoped to the current org.
+ */
+@RestController
+@RequestMapping("/tickets/{ticketId}/comments")
+@Tag(name = "Ticket Comments", description = "Comments for tickets")
+@Validated
+public class TicketCommentsController {
+
+    private final TicketCommentService commentService;
+
+    public TicketCommentsController(TicketCommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "List comments for a ticket")
+    public ResponseEntity<List<CommentResponse>> listComments(@PathVariable UUID ticketId) {
+        return ResponseEntity.ok(commentService.listComments(ticketId));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('ADMIN','MEMBER')")
+    @Operation(summary = "Create a comment for a ticket")
+    public ResponseEntity<CommentResponse> createComment(
+            @PathVariable UUID ticketId,
+            @Valid @RequestBody CreateCommentRequest request) {
+        CommentResponse response = commentService.createComment(ticketId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/AttachmentResponse.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/AttachmentResponse.java
@@ -1,0 +1,15 @@
+package com.jiralite.backend.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record AttachmentResponse(
+        UUID id,
+        String fileName,
+        String contentType,
+        long fileSize,
+        String status,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/CommentResponse.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/CommentResponse.java
@@ -1,0 +1,13 @@
+package com.jiralite.backend.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record CommentResponse(
+        UUID id,
+        UUID authorId,
+        String body,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/CreateCommentRequest.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/CreateCommentRequest.java
@@ -1,0 +1,17 @@
+package com.jiralite.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class CreateCommentRequest {
+
+    @NotBlank
+    private String body;
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/PresignDownloadResponse.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/PresignDownloadResponse.java
@@ -1,0 +1,11 @@
+package com.jiralite.backend.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record PresignDownloadResponse(
+        UUID attachmentId,
+        String downloadUrl,
+        OffsetDateTime expiresAt
+) {
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/PresignUploadRequest.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/PresignUploadRequest.java
@@ -1,0 +1,42 @@
+package com.jiralite.backend.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class PresignUploadRequest {
+
+    @NotBlank
+    private String fileName;
+
+    @NotBlank
+    private String contentType;
+
+    @NotNull
+    @Min(0)
+    private Long fileSize;
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public Long getFileSize() {
+        return fileSize;
+    }
+
+    public void setFileSize(Long fileSize) {
+        this.fileSize = fileSize;
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/dto/PresignUploadResponse.java
+++ b/backend/src/main/java/com/jiralite/backend/dto/PresignUploadResponse.java
@@ -1,0 +1,13 @@
+package com.jiralite.backend.dto;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+public record PresignUploadResponse(
+        UUID attachmentId,
+        String uploadUrl,
+        Map<String, String> headers,
+        OffsetDateTime expiresAt
+) {
+}

--- a/backend/src/main/java/com/jiralite/backend/entity/TicketAttachmentEntity.java
+++ b/backend/src/main/java/com/jiralite/backend/entity/TicketAttachmentEntity.java
@@ -1,0 +1,138 @@
+package com.jiralite.backend.entity;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Ticket attachment metadata stored in the database.
+ */
+@Entity
+@Table(name = "ticket_attachments")
+public class TicketAttachmentEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "org_id", nullable = false)
+    private UUID orgId;
+
+    @Column(name = "ticket_id", nullable = false)
+    private UUID ticketId;
+
+    @Column(name = "uploaded_by")
+    private UUID uploadedBy;
+
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
+
+    @Column(name = "content_type", nullable = false)
+    private String contentType;
+
+    @Column(name = "file_size", nullable = false)
+    private long fileSize;
+
+    @Column(name = "s3_key")
+    private String s3Key;
+
+    @Column(name = "upload_status", nullable = false)
+    private String uploadStatus;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(UUID orgId) {
+        this.orgId = orgId;
+    }
+
+    public UUID getTicketId() {
+        return ticketId;
+    }
+
+    public void setTicketId(UUID ticketId) {
+        this.ticketId = ticketId;
+    }
+
+    public UUID getUploadedBy() {
+        return uploadedBy;
+    }
+
+    public void setUploadedBy(UUID uploadedBy) {
+        this.uploadedBy = uploadedBy;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public long getFileSize() {
+        return fileSize;
+    }
+
+    public void setFileSize(long fileSize) {
+        this.fileSize = fileSize;
+    }
+
+    public String getS3Key() {
+        return s3Key;
+    }
+
+    public void setS3Key(String s3Key) {
+        this.s3Key = s3Key;
+    }
+
+    public String getUploadStatus() {
+        return uploadStatus;
+    }
+
+    public void setUploadStatus(String uploadStatus) {
+        this.uploadStatus = uploadStatus;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(OffsetDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/entity/TicketCommentEntity.java
+++ b/backend/src/main/java/com/jiralite/backend/entity/TicketCommentEntity.java
@@ -1,0 +1,94 @@
+package com.jiralite.backend.entity;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Ticket comment entity scoped to a tenant org.
+ */
+@Entity
+@Table(name = "ticket_comments")
+public class TicketCommentEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "org_id", nullable = false)
+    private UUID orgId;
+
+    @Column(name = "ticket_id", nullable = false)
+    private UUID ticketId;
+
+    @Column(name = "author_id")
+    private UUID authorId;
+
+    @Column(nullable = false)
+    private String body;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(UUID orgId) {
+        this.orgId = orgId;
+    }
+
+    public UUID getTicketId() {
+        return ticketId;
+    }
+
+    public void setTicketId(UUID ticketId) {
+        this.ticketId = ticketId;
+    }
+
+    public UUID getAuthorId() {
+        return authorId;
+    }
+
+    public void setAuthorId(UUID authorId) {
+        this.authorId = authorId;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(OffsetDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/repository/TicketAttachmentRepository.java
+++ b/backend/src/main/java/com/jiralite/backend/repository/TicketAttachmentRepository.java
@@ -1,0 +1,15 @@
+package com.jiralite.backend.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.jiralite.backend.entity.TicketAttachmentEntity;
+
+public interface TicketAttachmentRepository extends JpaRepository<TicketAttachmentEntity, UUID> {
+    List<TicketAttachmentEntity> findAllByOrgIdAndTicketIdOrderByCreatedAtAsc(UUID orgId, UUID ticketId);
+
+    Optional<TicketAttachmentEntity> findByIdAndOrgId(UUID id, UUID orgId);
+}

--- a/backend/src/main/java/com/jiralite/backend/repository/TicketCommentRepository.java
+++ b/backend/src/main/java/com/jiralite/backend/repository/TicketCommentRepository.java
@@ -1,0 +1,12 @@
+package com.jiralite.backend.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.jiralite.backend.entity.TicketCommentEntity;
+
+public interface TicketCommentRepository extends JpaRepository<TicketCommentEntity, UUID> {
+    List<TicketCommentEntity> findAllByOrgIdAndTicketIdOrderByCreatedAtAsc(UUID orgId, UUID ticketId);
+}

--- a/backend/src/main/java/com/jiralite/backend/service/S3PresignService.java
+++ b/backend/src/main/java/com/jiralite/backend/service/S3PresignService.java
@@ -1,0 +1,81 @@
+package com.jiralite.backend.service;
+
+import java.net.URL;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+/**
+ * Generates S3 presigned URLs for uploads and downloads.
+ */
+@Service
+public class S3PresignService {
+
+    private final S3Presigner presigner;
+    private final String bucket;
+    private final Duration uploadExpiry;
+    private final Duration downloadExpiry;
+
+    public S3PresignService(
+            S3Presigner presigner,
+            @Value("${app.s3.bucket}") String bucket,
+            @Value("${app.s3.upload-expiry-seconds:300}") long uploadExpirySeconds,
+            @Value("${app.s3.download-expiry-seconds:300}") long downloadExpirySeconds) {
+        this.presigner = presigner;
+        this.bucket = bucket;
+        this.uploadExpiry = Duration.ofSeconds(uploadExpirySeconds);
+        this.downloadExpiry = Duration.ofSeconds(downloadExpirySeconds);
+    }
+
+    public PresignResult presignUpload(String key, String contentType) {
+        PutObjectRequest putRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .putObjectRequest(putRequest)
+                .signatureDuration(uploadExpiry)
+                .build();
+
+        PresignedPutObjectRequest presigned = presigner.presignPutObject(presignRequest);
+        Map<String, String> headers = new HashMap<>();
+        presigned.signedHeaders().forEach((headerName, values) -> headers.put(headerName, String.join(",", values)));
+        return new PresignResult(presigned.url(), headers, OffsetDateTime.now().plusSeconds(uploadExpiry.getSeconds()));
+    }
+
+    public PresignResult presignDownload(String key) {
+        GetObjectRequest getRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .getObjectRequest(getRequest)
+                .signatureDuration(downloadExpiry)
+                .build();
+
+        PresignedGetObjectRequest presigned = presigner.presignGetObject(presignRequest);
+        return new PresignResult(presigned.url(), Map.of(),
+                OffsetDateTime.now().plusSeconds(downloadExpiry.getSeconds()));
+    }
+
+    public record PresignResult(URL url, Map<String, String> headers, OffsetDateTime expiresAt) {
+        public Map<String, String> headersOrEmpty() {
+            return headers == null ? Map.of() : new HashMap<>(headers);
+        }
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/service/TicketAttachmentService.java
+++ b/backend/src/main/java/com/jiralite/backend/service/TicketAttachmentService.java
@@ -1,0 +1,165 @@
+package com.jiralite.backend.service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jiralite.backend.dto.AttachmentResponse;
+import com.jiralite.backend.dto.ErrorCode;
+import com.jiralite.backend.dto.PresignDownloadResponse;
+import com.jiralite.backend.dto.PresignUploadRequest;
+import com.jiralite.backend.dto.PresignUploadResponse;
+import com.jiralite.backend.entity.TicketAttachmentEntity;
+import com.jiralite.backend.entity.TicketEntity;
+import com.jiralite.backend.exception.ApiException;
+import com.jiralite.backend.repository.TicketAttachmentRepository;
+import com.jiralite.backend.repository.TicketRepository;
+import com.jiralite.backend.security.tenant.TenantContext;
+import com.jiralite.backend.security.tenant.TenantContextHolder;
+
+/**
+ * Ticket attachment management scoped to the current tenant.
+ */
+@Service
+public class TicketAttachmentService {
+
+    private static final String STATUS_PENDING = "PENDING";
+    private static final String STATUS_UPLOADED = "UPLOADED";
+
+    private final TicketRepository ticketRepository;
+    private final TicketAttachmentRepository attachmentRepository;
+    private final S3PresignService s3PresignService;
+
+    public TicketAttachmentService(
+            TicketRepository ticketRepository,
+            TicketAttachmentRepository attachmentRepository,
+            S3PresignService s3PresignService) {
+        this.ticketRepository = ticketRepository;
+        this.attachmentRepository = attachmentRepository;
+        this.s3PresignService = s3PresignService;
+    }
+
+    @Transactional(readOnly = true)
+    public List<AttachmentResponse> listAttachments(UUID ticketId) {
+        TicketEntity ticket = getTicket(ticketId);
+        return attachmentRepository.findAllByOrgIdAndTicketIdOrderByCreatedAtAsc(ticket.getOrgId(), ticket.getId())
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public PresignUploadResponse presignUpload(UUID ticketId, PresignUploadRequest request) {
+        TicketEntity ticket = getTicket(ticketId);
+        OffsetDateTime now = OffsetDateTime.now();
+
+        TicketAttachmentEntity attachment = new TicketAttachmentEntity();
+        attachment.setId(UUID.randomUUID());
+        attachment.setOrgId(ticket.getOrgId());
+        attachment.setTicketId(ticket.getId());
+        attachment.setUploadedBy(parseUuidOrNull(getUserId()));
+        attachment.setFileName(request.getFileName());
+        attachment.setContentType(request.getContentType());
+        attachment.setFileSize(request.getFileSize());
+        attachment.setUploadStatus(STATUS_PENDING);
+        attachment.setCreatedAt(now);
+        attachment.setUpdatedAt(now);
+
+        String s3Key = buildS3Key(ticket.getOrgId(), ticket.getId(), attachment.getId(), request.getFileName());
+        attachment.setS3Key(s3Key);
+
+        TicketAttachmentEntity saved = attachmentRepository.save(attachment);
+        S3PresignService.PresignResult presign = s3PresignService.presignUpload(s3Key, request.getContentType());
+
+        return new PresignUploadResponse(
+                saved.getId(),
+                presign.url().toString(),
+                presign.headersOrEmpty(),
+                presign.expiresAt());
+    }
+
+    @Transactional
+    public AttachmentResponse confirmUpload(UUID ticketId, UUID attachmentId) {
+        TicketAttachmentEntity attachment = getAttachment(attachmentId);
+        if (!attachment.getTicketId().equals(ticketId)) {
+            throw new ApiException(ErrorCode.NOT_FOUND, "Attachment not found", HttpStatus.NOT_FOUND.value());
+        }
+        attachment.setUploadStatus(STATUS_UPLOADED);
+        attachment.setUpdatedAt(OffsetDateTime.now());
+        return toResponse(attachment);
+    }
+
+    @Transactional(readOnly = true)
+    public PresignDownloadResponse presignDownload(UUID ticketId, UUID attachmentId) {
+        TicketAttachmentEntity attachment = getAttachment(attachmentId);
+        if (!attachment.getTicketId().equals(ticketId)) {
+            throw new ApiException(ErrorCode.NOT_FOUND, "Attachment not found", HttpStatus.NOT_FOUND.value());
+        }
+        if (attachment.getS3Key() == null || attachment.getS3Key().isBlank()) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "Attachment not ready", HttpStatus.BAD_REQUEST.value());
+        }
+        S3PresignService.PresignResult presign = s3PresignService.presignDownload(attachment.getS3Key());
+        return new PresignDownloadResponse(
+                attachment.getId(),
+                presign.url().toString(),
+                presign.expiresAt());
+    }
+
+    private TicketEntity getTicket(UUID ticketId) {
+        UUID orgId = getOrgId();
+        return ticketRepository.findByIdAndOrgId(ticketId, orgId)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "Ticket not found",
+                        HttpStatus.NOT_FOUND.value()));
+    }
+
+    private TicketAttachmentEntity getAttachment(UUID attachmentId) {
+        UUID orgId = getOrgId();
+        return attachmentRepository.findByIdAndOrgId(attachmentId, orgId)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "Attachment not found",
+                        HttpStatus.NOT_FOUND.value()));
+    }
+
+    private UUID getOrgId() {
+        TenantContext context = TenantContextHolder.getRequired();
+        if (context.orgId() == null || context.orgId().isBlank()) {
+            throw new ApiException(ErrorCode.UNAUTHORIZED, "Missing org context", HttpStatus.UNAUTHORIZED.value());
+        }
+        return UUID.fromString(context.orgId());
+    }
+
+    private String getUserId() {
+        TenantContext context = TenantContextHolder.getRequired();
+        return context.userId();
+    }
+
+    private UUID parseUuidOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private String buildS3Key(UUID orgId, UUID ticketId, UUID attachmentId, String fileName) {
+        String safeName = fileName == null ? "file" : fileName.replaceAll("\\s+", "_");
+        return "org/" + orgId + "/tickets/" + ticketId + "/" + attachmentId + "-" + safeName;
+    }
+
+    private AttachmentResponse toResponse(TicketAttachmentEntity attachment) {
+        return new AttachmentResponse(
+                attachment.getId(),
+                attachment.getFileName(),
+                attachment.getContentType(),
+                attachment.getFileSize(),
+                attachment.getUploadStatus(),
+                attachment.getCreatedAt(),
+                attachment.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/com/jiralite/backend/service/TicketCommentService.java
+++ b/backend/src/main/java/com/jiralite/backend/service/TicketCommentService.java
@@ -1,0 +1,104 @@
+package com.jiralite.backend.service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jiralite.backend.dto.CommentResponse;
+import com.jiralite.backend.dto.CreateCommentRequest;
+import com.jiralite.backend.dto.ErrorCode;
+import com.jiralite.backend.entity.TicketCommentEntity;
+import com.jiralite.backend.entity.TicketEntity;
+import com.jiralite.backend.exception.ApiException;
+import com.jiralite.backend.repository.TicketCommentRepository;
+import com.jiralite.backend.repository.TicketRepository;
+import com.jiralite.backend.security.tenant.TenantContext;
+import com.jiralite.backend.security.tenant.TenantContextHolder;
+
+/**
+ * Ticket comment management scoped to the current tenant.
+ */
+@Service
+public class TicketCommentService {
+
+    private final TicketRepository ticketRepository;
+    private final TicketCommentRepository commentRepository;
+
+    public TicketCommentService(
+            TicketRepository ticketRepository,
+            TicketCommentRepository commentRepository) {
+        this.ticketRepository = ticketRepository;
+        this.commentRepository = commentRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> listComments(UUID ticketId) {
+        TicketEntity ticket = getTicket(ticketId);
+        return commentRepository.findAllByOrgIdAndTicketIdOrderByCreatedAtAsc(ticket.getOrgId(), ticket.getId())
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public CommentResponse createComment(UUID ticketId, CreateCommentRequest request) {
+        TicketEntity ticket = getTicket(ticketId);
+        OffsetDateTime now = OffsetDateTime.now();
+
+        TicketCommentEntity comment = new TicketCommentEntity();
+        comment.setId(UUID.randomUUID());
+        comment.setOrgId(ticket.getOrgId());
+        comment.setTicketId(ticket.getId());
+        comment.setAuthorId(parseUuidOrNull(getUserId()));
+        comment.setBody(request.getBody());
+        comment.setCreatedAt(now);
+        comment.setUpdatedAt(now);
+
+        TicketCommentEntity saved = commentRepository.save(comment);
+        return toResponse(saved);
+    }
+
+    private TicketEntity getTicket(UUID ticketId) {
+        UUID orgId = getOrgId();
+        return ticketRepository.findByIdAndOrgId(ticketId, orgId)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "Ticket not found",
+                        HttpStatus.NOT_FOUND.value()));
+    }
+
+    private UUID getOrgId() {
+        TenantContext context = TenantContextHolder.getRequired();
+        if (context.orgId() == null || context.orgId().isBlank()) {
+            throw new ApiException(ErrorCode.UNAUTHORIZED, "Missing org context", HttpStatus.UNAUTHORIZED.value());
+        }
+        return UUID.fromString(context.orgId());
+    }
+
+    private String getUserId() {
+        TenantContext context = TenantContextHolder.getRequired();
+        return context.userId();
+    }
+
+    private UUID parseUuidOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private CommentResponse toResponse(TicketCommentEntity comment) {
+        return new CommentResponse(
+                comment.getId(),
+                comment.getAuthorId(),
+                comment.getBody(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt());
+    }
+}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -32,3 +32,8 @@ logging:
 app: # app configuration
   security:
     org-claim: ${ORG_CLAIM:custom:org_id} # org claim
+  s3:
+    bucket: ${S3_BUCKET:jira-lite-attachments}
+    region: ${AWS_REGION:ap-southeast-2}
+    upload-expiry-seconds: ${S3_UPLOAD_EXPIRY_SECONDS:300}
+    download-expiry-seconds: ${S3_DOWNLOAD_EXPIRY_SECONDS:300}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,6 +8,12 @@ spring:
 server:
   port: ${SERVER_PORT:8080} # server port
 
+app:
+  s3:
+    bucket: ${S3_BUCKET:jira-lite-attachments}
+    region: ${AWS_REGION:ap-southeast-2}
+    upload-expiry-seconds: ${S3_UPLOAD_EXPIRY_SECONDS:300}
+    download-expiry-seconds: ${S3_DOWNLOAD_EXPIRY_SECONDS:300}
 
 # Note:
 # - Do not hardcode local DB settings here.

--- a/backend/src/main/resources/db/migration/V8__comments_attachments.sql
+++ b/backend/src/main/resources/db/migration/V8__comments_attachments.sql
@@ -1,0 +1,15 @@
+-- V8: Ticket comments + attachments constraints/indexes
+
+CREATE INDEX IF NOT EXISTS idx_comments_org_ticket ON ticket_comments(org_id, ticket_id);
+CREATE INDEX IF NOT EXISTS idx_attachments_org_ticket ON ticket_attachments(org_id, ticket_id);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'ticket_attachments' AND constraint_name = 'ck_ticket_attachment_upload_status'
+    ) THEN
+        ALTER TABLE ticket_attachments
+          ADD CONSTRAINT ck_ticket_attachment_upload_status CHECK (upload_status IN ('PENDING', 'UPLOADED', 'FAILED'));
+    END IF;
+END $$;

--- a/backend/src/test/java/com/jiralite/backend/TicketAttachmentsIntegrationTest.java
+++ b/backend/src/test/java/com/jiralite/backend/TicketAttachmentsIntegrationTest.java
@@ -1,0 +1,207 @@
+package com.jiralite.backend;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URL;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.jiralite.backend.entity.OrgEntity;
+import com.jiralite.backend.entity.ProjectEntity;
+import com.jiralite.backend.entity.TicketAttachmentEntity;
+import com.jiralite.backend.entity.TicketEntity;
+import com.jiralite.backend.repository.OrgRepository;
+import com.jiralite.backend.repository.ProjectRepository;
+import com.jiralite.backend.repository.TicketAttachmentRepository;
+import com.jiralite.backend.repository.TicketRepository;
+import com.jiralite.backend.security.TestJwtDecoderConfig;
+import com.jiralite.backend.service.S3PresignService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(TestJwtDecoderConfig.class)
+class TicketAttachmentsIntegrationTest {
+
+    private static final UUID ORG_1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID ORG_2 = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID PROJECT_1 = UUID.fromString("aaaaaaaa-1111-1111-1111-111111111111");
+    private static final UUID PROJECT_2 = UUID.fromString("bbbbbbbb-2222-2222-2222-222222222222");
+    private static final UUID TICKET_1 = UUID.fromString("cccccccc-3333-3333-3333-333333333333");
+    private static final UUID TICKET_2 = UUID.fromString("dddddddd-4444-4444-4444-444444444444");
+    private static final UUID ATTACHMENT_1 = UUID.fromString("eeeeeeee-5555-5555-5555-555555555555");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private OrgRepository orgRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private TicketAttachmentRepository attachmentRepository;
+
+    @MockBean
+    private S3PresignService s3PresignService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        attachmentRepository.deleteAll();
+        ticketRepository.deleteAll();
+        projectRepository.deleteAll();
+        orgRepository.deleteAll();
+
+        orgRepository.save(org("Org One", ORG_1));
+        orgRepository.save(org("Org Two", ORG_2));
+
+        projectRepository.save(project(PROJECT_1, ORG_1, "JIRA", "Jira Lite"));
+        projectRepository.save(project(PROJECT_2, ORG_2, "OPS", "Ops Portal"));
+
+        ticketRepository.save(ticket(TICKET_1, ORG_1, PROJECT_1, "JIRA-1", "First ticket"));
+        ticketRepository.save(ticket(TICKET_2, ORG_2, PROJECT_2, "OPS-1", "Other org"));
+
+        attachmentRepository.save(attachment(ATTACHMENT_1, ORG_1, TICKET_1, "log.txt", "text/plain", 12L, "UPLOADED"));
+
+        when(s3PresignService.presignUpload(any(), any()))
+                .thenReturn(new S3PresignService.PresignResult(
+                        new URL("https://example.com/upload"),
+                        Map.of("Content-Type", "text/plain"),
+                        OffsetDateTime.now().plusMinutes(5)));
+
+        when(s3PresignService.presignDownload(any()))
+                .thenReturn(new S3PresignService.PresignResult(
+                        new URL("https://example.com/download"),
+                        Map.of(),
+                        OffsetDateTime.now().plusMinutes(5)));
+    }
+
+    @Test
+    void list_requires_authentication() throws Exception {
+        mockMvc.perform(get("/tickets/{ticketId}/attachments", TICKET_1))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.traceId", notNullValue()));
+    }
+
+    @Test
+    void member_lists_attachments() throws Exception {
+        mockMvc.perform(get("/tickets/{ticketId}/attachments", TICKET_1)
+                        .header("Authorization", "Bearer member-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].fileName").value("log.txt"));
+    }
+
+    @Test
+    void member_can_presign_upload() throws Exception {
+        String payload = "{\"fileName\":\"log.txt\",\"contentType\":\"text/plain\",\"fileSize\":12}";
+        mockMvc.perform(post("/tickets/{ticketId}/attachments/presign-upload", TICKET_1)
+                        .header("Authorization", "Bearer member-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.attachmentId").value(notNullValue()))
+                .andExpect(jsonPath("$.uploadUrl").value("https://example.com/upload"));
+    }
+
+    @Test
+    void member_can_presign_download() throws Exception {
+        mockMvc.perform(get("/tickets/{ticketId}/attachments/{attachmentId}/presign-download", TICKET_1, ATTACHMENT_1)
+                        .header("Authorization", "Bearer member-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.downloadUrl").value("https://example.com/download"));
+    }
+
+    @Test
+    void member_cannot_access_other_org_attachment() throws Exception {
+        mockMvc.perform(get("/tickets/{ticketId}/attachments", TICKET_2)
+                        .header("Authorization", "Bearer member-token"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void confirm_upload_updates_status() throws Exception {
+        mockMvc.perform(post("/tickets/{ticketId}/attachments/{attachmentId}/confirm", TICKET_1, ATTACHMENT_1)
+                        .header("Authorization", "Bearer member-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UPLOADED"));
+    }
+
+    private OrgEntity org(String name, UUID id) {
+        OrgEntity org = new OrgEntity();
+        org.setId(id);
+        org.setName(name);
+        org.setCreatedAt(OffsetDateTime.now());
+        org.setUpdatedAt(OffsetDateTime.now());
+        return org;
+    }
+
+    private ProjectEntity project(UUID id, UUID orgId, String key, String name) {
+        ProjectEntity project = new ProjectEntity();
+        project.setId(id);
+        project.setOrgId(orgId);
+        project.setProjectKey(key);
+        project.setName(name);
+        project.setDescription("Seeded project");
+        project.setStatus("ACTIVE");
+        project.setCreatedAt(OffsetDateTime.now());
+        project.setUpdatedAt(OffsetDateTime.now());
+        return project;
+    }
+
+    private TicketEntity ticket(UUID id, UUID orgId, UUID projectId, String key, String title) {
+        TicketEntity ticket = new TicketEntity();
+        ticket.setId(id);
+        ticket.setOrgId(orgId);
+        ticket.setProjectId(projectId);
+        ticket.setTicketKey(key);
+        ticket.setTitle(title);
+        ticket.setDescription("Seeded ticket");
+        ticket.setStatus("OPEN");
+        ticket.setPriority("MEDIUM");
+        ticket.setCreatedAt(OffsetDateTime.now());
+        ticket.setUpdatedAt(OffsetDateTime.now());
+        return ticket;
+    }
+
+    private TicketAttachmentEntity attachment(UUID id, UUID orgId, UUID ticketId, String fileName,
+            String contentType, long fileSize, String status) {
+        TicketAttachmentEntity attachment = new TicketAttachmentEntity();
+        attachment.setId(id);
+        attachment.setOrgId(orgId);
+        attachment.setTicketId(ticketId);
+        attachment.setFileName(fileName);
+        attachment.setContentType(contentType);
+        attachment.setFileSize(fileSize);
+        attachment.setUploadStatus(status);
+        attachment.setS3Key("org/" + orgId + "/tickets/" + ticketId + "/" + id);
+        attachment.setCreatedAt(OffsetDateTime.now());
+        attachment.setUpdatedAt(OffsetDateTime.now());
+        return attachment;
+    }
+}

--- a/backend/src/test/java/com/jiralite/backend/TicketAttachmentsTcIntegrationTest.java
+++ b/backend/src/test/java/com/jiralite/backend/TicketAttachmentsTcIntegrationTest.java
@@ -1,0 +1,253 @@
+package com.jiralite.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.net.URL;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jiralite.backend.entity.OrgEntity;
+import com.jiralite.backend.entity.ProjectEntity;
+import com.jiralite.backend.entity.TicketAttachmentEntity;
+import com.jiralite.backend.entity.TicketEntity;
+import com.jiralite.backend.repository.OrgRepository;
+import com.jiralite.backend.repository.ProjectRepository;
+import com.jiralite.backend.repository.TicketAttachmentRepository;
+import com.jiralite.backend.repository.TicketRepository;
+import com.jiralite.backend.security.TestJwtDecoderConfig;
+import com.jiralite.backend.service.S3PresignService;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(TestJwtDecoderConfig.class)
+@Testcontainers
+@EnabledIfSystemProperty(named = "runTestcontainers", matches = "true")
+class TicketAttachmentsTcIntegrationTest {
+
+    private static final UUID ORG_1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID ORG_2 = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID PROJECT_1 = UUID.fromString("aaaaaaaa-1111-1111-1111-111111111111");
+    private static final UUID PROJECT_2 = UUID.fromString("bbbbbbbb-2222-2222-2222-222222222222");
+    private static final UUID TICKET_1 = UUID.fromString("cccccccc-3333-3333-3333-333333333333");
+    private static final UUID TICKET_2 = UUID.fromString("dddddddd-4444-4444-4444-444444444444");
+    private static final UUID ATTACHMENT_1 = UUID.fromString("eeeeeeee-5555-5555-5555-555555555555");
+
+    @Container
+    private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
+            .withDatabaseName("jira_lite")
+            .withUsername("jira_lite")
+            .withPassword("jira_lite_password");
+
+    @DynamicPropertySource
+    static void configureDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        registry.add("app.s3.bucket", () -> "test-bucket");
+        registry.add("app.s3.region", () -> "ap-southeast-2");
+    }
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private OrgRepository orgRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private TicketAttachmentRepository attachmentRepository;
+
+    @MockBean
+    private S3PresignService s3PresignService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        attachmentRepository.deleteAll();
+        ticketRepository.deleteAll();
+        projectRepository.deleteAll();
+        orgRepository.deleteAll();
+
+        orgRepository.save(org("Org One", ORG_1));
+        orgRepository.save(org("Org Two", ORG_2));
+
+        projectRepository.save(project(PROJECT_1, ORG_1, "JIRA", "Jira Lite"));
+        projectRepository.save(project(PROJECT_2, ORG_2, "OPS", "Ops Portal"));
+
+        ticketRepository.save(ticket(TICKET_1, ORG_1, PROJECT_1, "JIRA-1", "First ticket"));
+        ticketRepository.save(ticket(TICKET_2, ORG_2, PROJECT_2, "OPS-1", "Other org"));
+
+        attachmentRepository.save(attachment(ATTACHMENT_1, ORG_1, TICKET_1, "log.txt", "text/plain", 12L, "UPLOADED"));
+
+        when(s3PresignService.presignUpload(any(), any()))
+                .thenReturn(new S3PresignService.PresignResult(
+                        new URL("https://example.com/upload"),
+                        Map.of("Content-Type", "text/plain"),
+                        OffsetDateTime.now().plusMinutes(5)));
+
+        when(s3PresignService.presignDownload(any()))
+                .thenReturn(new S3PresignService.PresignResult(
+                        new URL("https://example.com/download"),
+                        Map.of(),
+                        OffsetDateTime.now().plusMinutes(5)));
+    }
+
+    @Test
+    void member_lists_attachments() throws Exception {
+        ResponseEntity<String> response = restTemplate.exchange(
+                url("/tickets/" + TICKET_1 + "/attachments"),
+                HttpMethod.GET,
+                authEntity("member-token", null),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertThat(body.size()).isEqualTo(1);
+        assertThat(body.get(0).get("fileName").asText()).isEqualTo("log.txt");
+    }
+
+    @Test
+    void member_can_presign_upload() throws Exception {
+        String payload = "{\"fileName\":\"log.txt\",\"contentType\":\"text/plain\",\"fileSize\":12}";
+        ResponseEntity<String> response = restTemplate.exchange(
+                url("/tickets/" + TICKET_1 + "/attachments/presign-upload"),
+                HttpMethod.POST,
+                authEntity("member-token", payload),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertThat(body.get("uploadUrl").asText()).isEqualTo("https://example.com/upload");
+    }
+
+    @Test
+    void member_can_presign_download() throws Exception {
+        ResponseEntity<String> response = restTemplate.exchange(
+                url("/tickets/" + TICKET_1 + "/attachments/" + ATTACHMENT_1 + "/presign-download"),
+                HttpMethod.GET,
+                authEntity("member-token", null),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertThat(body.get("downloadUrl").asText()).isEqualTo("https://example.com/download");
+    }
+
+    @Test
+    void member_cannot_access_other_org_attachments() throws Exception {
+        ResponseEntity<String> response = restTemplate.exchange(
+                url("/tickets/" + TICKET_2 + "/attachments"),
+                HttpMethod.GET,
+                authEntity("member-token", null),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertThat(body.get("code").asText()).isEqualTo("NOT_FOUND");
+    }
+
+    private String url(String path) {
+        return "http://localhost:" + port + path;
+    }
+
+    private HttpEntity<String> authEntity(String token, String body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        if (body != null) {
+            headers.setContentType(MediaType.APPLICATION_JSON);
+        }
+        return new HttpEntity<>(body, headers);
+    }
+
+    private OrgEntity org(String name, UUID id) {
+        OrgEntity org = new OrgEntity();
+        org.setId(id);
+        org.setName(name);
+        org.setCreatedAt(OffsetDateTime.now());
+        org.setUpdatedAt(OffsetDateTime.now());
+        return org;
+    }
+
+    private ProjectEntity project(UUID id, UUID orgId, String key, String name) {
+        ProjectEntity project = new ProjectEntity();
+        project.setId(id);
+        project.setOrgId(orgId);
+        project.setProjectKey(key);
+        project.setName(name);
+        project.setDescription("Seeded project");
+        project.setStatus("ACTIVE");
+        project.setCreatedAt(OffsetDateTime.now());
+        project.setUpdatedAt(OffsetDateTime.now());
+        return project;
+    }
+
+    private TicketEntity ticket(UUID id, UUID orgId, UUID projectId, String key, String title) {
+        TicketEntity ticket = new TicketEntity();
+        ticket.setId(id);
+        ticket.setOrgId(orgId);
+        ticket.setProjectId(projectId);
+        ticket.setTicketKey(key);
+        ticket.setTitle(title);
+        ticket.setDescription("Seeded ticket");
+        ticket.setStatus("OPEN");
+        ticket.setPriority("MEDIUM");
+        ticket.setCreatedAt(OffsetDateTime.now());
+        ticket.setUpdatedAt(OffsetDateTime.now());
+        return ticket;
+    }
+
+    private TicketAttachmentEntity attachment(UUID id, UUID orgId, UUID ticketId, String fileName,
+            String contentType, long fileSize, String status) {
+        TicketAttachmentEntity attachment = new TicketAttachmentEntity();
+        attachment.setId(id);
+        attachment.setOrgId(orgId);
+        attachment.setTicketId(ticketId);
+        attachment.setFileName(fileName);
+        attachment.setContentType(contentType);
+        attachment.setFileSize(fileSize);
+        attachment.setUploadStatus(status);
+        attachment.setS3Key("org/" + orgId + "/tickets/" + ticketId + "/" + id);
+        attachment.setCreatedAt(OffsetDateTime.now());
+        attachment.setUpdatedAt(OffsetDateTime.now());
+        return attachment;
+    }
+}

--- a/backend/src/test/java/com/jiralite/backend/TicketCommentsIntegrationTest.java
+++ b/backend/src/test/java/com/jiralite/backend/TicketCommentsIntegrationTest.java
@@ -1,0 +1,166 @@
+package com.jiralite.backend;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.jiralite.backend.entity.OrgEntity;
+import com.jiralite.backend.entity.ProjectEntity;
+import com.jiralite.backend.entity.TicketCommentEntity;
+import com.jiralite.backend.entity.TicketEntity;
+import com.jiralite.backend.repository.OrgRepository;
+import com.jiralite.backend.repository.ProjectRepository;
+import com.jiralite.backend.repository.TicketCommentRepository;
+import com.jiralite.backend.repository.TicketRepository;
+import com.jiralite.backend.security.TestJwtDecoderConfig;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(TestJwtDecoderConfig.class)
+class TicketCommentsIntegrationTest {
+
+    private static final UUID ORG_1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID ORG_2 = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID PROJECT_1 = UUID.fromString("aaaaaaaa-1111-1111-1111-111111111111");
+    private static final UUID PROJECT_2 = UUID.fromString("bbbbbbbb-2222-2222-2222-222222222222");
+    private static final UUID TICKET_1 = UUID.fromString("cccccccc-3333-3333-3333-333333333333");
+    private static final UUID TICKET_2 = UUID.fromString("dddddddd-4444-4444-4444-444444444444");
+    private static final UUID COMMENT_1 = UUID.fromString("eeeeeeee-5555-5555-5555-555555555555");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private OrgRepository orgRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private TicketCommentRepository commentRepository;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository.deleteAll();
+        ticketRepository.deleteAll();
+        projectRepository.deleteAll();
+        orgRepository.deleteAll();
+
+        orgRepository.save(org("Org One", ORG_1));
+        orgRepository.save(org("Org Two", ORG_2));
+
+        projectRepository.save(project(PROJECT_1, ORG_1, "JIRA", "Jira Lite"));
+        projectRepository.save(project(PROJECT_2, ORG_2, "OPS", "Ops Portal"));
+
+        ticketRepository.save(ticket(TICKET_1, ORG_1, PROJECT_1, "JIRA-1", "First ticket"));
+        ticketRepository.save(ticket(TICKET_2, ORG_2, PROJECT_2, "OPS-1", "Other org"));
+
+        commentRepository.save(comment(COMMENT_1, ORG_1, TICKET_1, "Seed comment"));
+    }
+
+    @Test
+    void list_requires_authentication() throws Exception {
+        mockMvc.perform(get("/tickets/{ticketId}/comments", TICKET_1))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.traceId", notNullValue()));
+    }
+
+    @Test
+    void member_lists_comments_for_ticket() throws Exception {
+        mockMvc.perform(get("/tickets/{ticketId}/comments", TICKET_1)
+                        .header("Authorization", "Bearer member-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].body").value("Seed comment"));
+    }
+
+    @Test
+    void member_cannot_access_other_org_comments() throws Exception {
+        mockMvc.perform(get("/tickets/{ticketId}/comments", TICKET_2)
+                        .header("Authorization", "Bearer member-token"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void member_can_create_comment() throws Exception {
+        String payload = "{\"body\":\"Hello\"}";
+        mockMvc.perform(post("/tickets/{ticketId}/comments", TICKET_1)
+                        .header("Authorization", "Bearer member-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.body").value("Hello"))
+                .andExpect(jsonPath("$.authorId").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    private OrgEntity org(String name, UUID id) {
+        OrgEntity org = new OrgEntity();
+        org.setId(id);
+        org.setName(name);
+        org.setCreatedAt(OffsetDateTime.now());
+        org.setUpdatedAt(OffsetDateTime.now());
+        return org;
+    }
+
+    private ProjectEntity project(UUID id, UUID orgId, String key, String name) {
+        ProjectEntity project = new ProjectEntity();
+        project.setId(id);
+        project.setOrgId(orgId);
+        project.setProjectKey(key);
+        project.setName(name);
+        project.setDescription("Seeded project");
+        project.setStatus("ACTIVE");
+        project.setCreatedAt(OffsetDateTime.now());
+        project.setUpdatedAt(OffsetDateTime.now());
+        return project;
+    }
+
+    private TicketEntity ticket(UUID id, UUID orgId, UUID projectId, String key, String title) {
+        TicketEntity ticket = new TicketEntity();
+        ticket.setId(id);
+        ticket.setOrgId(orgId);
+        ticket.setProjectId(projectId);
+        ticket.setTicketKey(key);
+        ticket.setTitle(title);
+        ticket.setDescription("Seeded ticket");
+        ticket.setStatus("OPEN");
+        ticket.setPriority("MEDIUM");
+        ticket.setCreatedAt(OffsetDateTime.now());
+        ticket.setUpdatedAt(OffsetDateTime.now());
+        return ticket;
+    }
+
+    private TicketCommentEntity comment(UUID id, UUID orgId, UUID ticketId, String body) {
+        TicketCommentEntity comment = new TicketCommentEntity();
+        comment.setId(id);
+        comment.setOrgId(orgId);
+        comment.setTicketId(ticketId);
+        comment.setAuthorId(null);
+        comment.setBody(body);
+        comment.setCreatedAt(OffsetDateTime.now());
+        comment.setUpdatedAt(OffsetDateTime.now());
+        return comment;
+    }
+}

--- a/backend/src/test/java/com/jiralite/backend/TicketCommentsTcIntegrationTest.java
+++ b/backend/src/test/java/com/jiralite/backend/TicketCommentsTcIntegrationTest.java
@@ -1,0 +1,215 @@
+package com.jiralite.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jiralite.backend.entity.OrgEntity;
+import com.jiralite.backend.entity.ProjectEntity;
+import com.jiralite.backend.entity.TicketCommentEntity;
+import com.jiralite.backend.entity.TicketEntity;
+import com.jiralite.backend.repository.OrgRepository;
+import com.jiralite.backend.repository.ProjectRepository;
+import com.jiralite.backend.repository.TicketCommentRepository;
+import com.jiralite.backend.repository.TicketRepository;
+import com.jiralite.backend.security.TestJwtDecoderConfig;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(TestJwtDecoderConfig.class)
+@Testcontainers
+@EnabledIfSystemProperty(named = "runTestcontainers", matches = "true")
+class TicketCommentsTcIntegrationTest {
+
+    private static final UUID ORG_1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID ORG_2 = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID PROJECT_1 = UUID.fromString("aaaaaaaa-1111-1111-1111-111111111111");
+    private static final UUID PROJECT_2 = UUID.fromString("bbbbbbbb-2222-2222-2222-222222222222");
+    private static final UUID TICKET_1 = UUID.fromString("cccccccc-3333-3333-3333-333333333333");
+    private static final UUID TICKET_2 = UUID.fromString("dddddddd-4444-4444-4444-444444444444");
+    private static final UUID COMMENT_1 = UUID.fromString("eeeeeeee-5555-5555-5555-555555555555");
+
+    @Container
+    private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
+            .withDatabaseName("jira_lite")
+            .withUsername("jira_lite")
+            .withPassword("jira_lite_password");
+
+    @DynamicPropertySource
+    static void configureDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        registry.add("app.s3.bucket", () -> "test-bucket");
+        registry.add("app.s3.region", () -> "ap-southeast-2");
+    }
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private OrgRepository orgRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private TicketCommentRepository commentRepository;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository.deleteAll();
+        ticketRepository.deleteAll();
+        projectRepository.deleteAll();
+        orgRepository.deleteAll();
+
+        orgRepository.save(org("Org One", ORG_1));
+        orgRepository.save(org("Org Two", ORG_2));
+
+        projectRepository.save(project(PROJECT_1, ORG_1, "JIRA", "Jira Lite"));
+        projectRepository.save(project(PROJECT_2, ORG_2, "OPS", "Ops Portal"));
+
+        ticketRepository.save(ticket(TICKET_1, ORG_1, PROJECT_1, "JIRA-1", "First ticket"));
+        ticketRepository.save(ticket(TICKET_2, ORG_2, PROJECT_2, "OPS-1", "Other org"));
+
+        commentRepository.save(comment(COMMENT_1, ORG_1, TICKET_1, "Seed comment"));
+    }
+
+    @Test
+    void member_lists_comments_for_ticket() throws Exception {
+        ResponseEntity<String> response = restTemplate.exchange(
+                url("/tickets/" + TICKET_1 + "/comments"),
+                HttpMethod.GET,
+                authEntity("member-token", null),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertThat(body.size()).isEqualTo(1);
+        assertThat(body.get(0).get("body").asText()).isEqualTo("Seed comment");
+    }
+
+    @Test
+    void member_cannot_access_other_org_comments() throws Exception {
+        ResponseEntity<String> response = restTemplate.exchange(
+                url("/tickets/" + TICKET_2 + "/comments"),
+                HttpMethod.GET,
+                authEntity("member-token", null),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertThat(body.get("code").asText()).isEqualTo("NOT_FOUND");
+    }
+
+    @Test
+    void member_can_create_comment() throws Exception {
+        String payload = "{\"body\":\"Hello\"}";
+        ResponseEntity<String> response = restTemplate.exchange(
+                url("/tickets/" + TICKET_1 + "/comments"),
+                HttpMethod.POST,
+                authEntity("member-token", payload),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertThat(body.get("body").asText()).isEqualTo("Hello");
+    }
+
+    private String url(String path) {
+        return "http://localhost:" + port + path;
+    }
+
+    private HttpEntity<String> authEntity(String token, String body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        if (body != null) {
+            headers.setContentType(MediaType.APPLICATION_JSON);
+        }
+        return new HttpEntity<>(body, headers);
+    }
+
+    private OrgEntity org(String name, UUID id) {
+        OrgEntity org = new OrgEntity();
+        org.setId(id);
+        org.setName(name);
+        org.setCreatedAt(OffsetDateTime.now());
+        org.setUpdatedAt(OffsetDateTime.now());
+        return org;
+    }
+
+    private ProjectEntity project(UUID id, UUID orgId, String key, String name) {
+        ProjectEntity project = new ProjectEntity();
+        project.setId(id);
+        project.setOrgId(orgId);
+        project.setProjectKey(key);
+        project.setName(name);
+        project.setDescription("Seeded project");
+        project.setStatus("ACTIVE");
+        project.setCreatedAt(OffsetDateTime.now());
+        project.setUpdatedAt(OffsetDateTime.now());
+        return project;
+    }
+
+    private TicketEntity ticket(UUID id, UUID orgId, UUID projectId, String key, String title) {
+        TicketEntity ticket = new TicketEntity();
+        ticket.setId(id);
+        ticket.setOrgId(orgId);
+        ticket.setProjectId(projectId);
+        ticket.setTicketKey(key);
+        ticket.setTitle(title);
+        ticket.setDescription("Seeded ticket");
+        ticket.setStatus("OPEN");
+        ticket.setPriority("MEDIUM");
+        ticket.setCreatedAt(OffsetDateTime.now());
+        ticket.setUpdatedAt(OffsetDateTime.now());
+        return ticket;
+    }
+
+    private TicketCommentEntity comment(UUID id, UUID orgId, UUID ticketId, String body) {
+        TicketCommentEntity comment = new TicketCommentEntity();
+        comment.setId(id);
+        comment.setOrgId(orgId);
+        comment.setTicketId(ticketId);
+        comment.setAuthorId(null);
+        comment.setBody(body);
+        comment.setCreatedAt(OffsetDateTime.now());
+        comment.setUpdatedAt(OffsetDateTime.now());
+        return comment;
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -4,3 +4,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+
+app:
+  s3:
+    bucket: test-bucket
+    region: ap-southeast-2
+    upload-expiry-seconds: 300
+    download-expiry-seconds: 300

--- a/docs/adr/ADR-0008-comments-attachments-presigned.md
+++ b/docs/adr/ADR-0008-comments-attachments-presigned.md
@@ -1,0 +1,23 @@
+# ADR-0008: Comments and Attachments with S3 Presigned URLs
+
+## Status
+
+Accepted
+
+## Context
+
+The system needs ticket comments and attachments. Files must be uploaded without
+proxying through the backend. Presigned URLs enable direct S3 upload/download.
+
+## Decision
+
+- Implement ticket comments (list/create) scoped by orgId from TenantContext.
+- Implement attachment metadata storage and presigned upload/download URLs.
+- Use S3Presigner (AWS SDK v2) with short-lived URLs.
+- Store attachment metadata with upload_status (PENDING/UPLOADED/FAILED).
+
+## Consequences
+
+- Upload requires a confirm call to mark status as UPLOADED.
+- No secrets are stored in code; bucket/region are configured via env variables.
+- Future work: delete attachments, virus scan, and lifecycle policies.

--- a/docs/design/attachments.md
+++ b/docs/design/attachments.md
@@ -1,0 +1,47 @@
+# Ticket Attachments (S3 Presigned)
+
+## Overview
+
+Attachments use S3 presigned URLs for upload and download. The backend stores
+metadata and validates tenant ownership.
+
+## C4 Context
+
+```mermaid
+C4Context
+title ticket-attachments
+Person(user, "User")
+System(be, "Backend")
+System_Ext(cognito, "AWS Cognito")
+System_Ext(s3, "AWS S3")
+SystemDb(db, "Postgres")
+Rel(user, cognito, "Login")
+Rel(user, be, "Request presigned URLs")
+Rel(be, s3, "Presign upload/download")
+Rel(be, db, "Store attachment metadata")
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+title attachment-upload
+participant U as Member
+participant API as Backend
+participant SEC as Spring Security
+participant TC as TenantContext
+participant SVC as TicketAttachmentService
+participant S3 as S3Presigner
+participant DB as Postgres
+
+U->>API: POST /tickets/{id}/attachments/presign-upload + JWT
+API->>SEC: Validate JWT
+SEC-->>TC: Authenticated
+TC->>SVC: orgId from TenantContext
+SVC->>DB: Verify ticket belongs to org
+DB-->>SVC: OK
+SVC->>S3: Create presigned PUT
+S3-->>SVC: uploadUrl + headers
+SVC->>DB: Save attachment metadata (PENDING)
+SVC-->>API: PresignUploadResponse
+```

--- a/docs/design/comments.md
+++ b/docs/design/comments.md
@@ -1,0 +1,43 @@
+# Ticket Comments
+
+## Overview
+
+Comments are scoped to the current org and ticket. The author is derived from JWT claims.
+
+## C4 Context
+
+```mermaid
+C4Context
+title ticket-comments
+Person(user, "User")
+System(be, "Backend")
+System_Ext(cognito, "AWS Cognito")
+SystemDb(db, "Postgres")
+Rel(user, cognito, "Login")
+Rel(user, be, "Read/write comments")
+Rel(be, cognito, "Validate JWT + org_id")
+Rel(be, db, "Store comments")
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+title comment-create
+participant U as Member
+participant API as Backend
+participant SEC as Spring Security
+participant TC as TenantContext
+participant SVC as TicketCommentService
+participant DB as Postgres
+
+U->>API: POST /tickets/{id}/comments + JWT
+API->>SEC: Validate JWT
+SEC-->>TC: Authenticated
+TC->>SVC: orgId from TenantContext
+SVC->>DB: Verify ticket belongs to org
+DB-->>SVC: OK
+SVC->>DB: Insert comment
+DB-->>SVC: Comment
+SVC-->>API: CommentResponse
+```

--- a/docs/design/multi-tenancy.md
+++ b/docs/design/multi-tenancy.md
@@ -33,6 +33,11 @@ projects using `orgId` from `TenantContextHolder` and never accept orgId from cl
 Ticket list/detail/create/update/transition must always scope by `orgId` from
 `TenantContextHolder`. Any cross-org access should return 404 to avoid leakage.
 
+## Comments & Attachments
+
+Ticket comments and attachments must verify the ticket belongs to the current org.
+All reads/writes must include `orgId` from `TenantContextHolder`.
+
 ### C4 Context
 
 ```mermaid

--- a/docs/design/openapi.md
+++ b/docs/design/openapi.md
@@ -69,6 +69,16 @@ All endpoints are automatically documented in Swagger UI:
 - **PATCH** `/tickets/{ticketId}`
 - **POST** `/tickets/{ticketId}/transition`
 
+### Ticket Comments
+- **GET** `/tickets/{ticketId}/comments`
+- **POST** `/tickets/{ticketId}/comments`
+
+### Ticket Attachments
+- **POST** `/tickets/{ticketId}/attachments/presign-upload`
+- **GET** `/tickets/{ticketId}/attachments`
+- **POST** `/tickets/{ticketId}/attachments/{attachmentId}/confirm`
+- **GET** `/tickets/{ticketId}/attachments/{attachmentId}/presign-download`
+
 ## Swagger Configuration
 
 ### OpenApiConfig

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -166,6 +166,48 @@ cd backend
 ./mvnw test -Dtest=TicketsTcIntegrationTest -DrunTestcontainers=true
 ```
 
+## Day 8: Comments + Attachments (S3 Presigned)
+
+### Verify Day 8 Comments
+
+```bash
+# List comments
+curl.exe -i -H "Authorization: Bearer <JWT>" ^
+  http://localhost:8080/tickets/<TICKET_ID>/comments
+
+# Create comment
+curl.exe -i -X POST http://localhost:8080/tickets/<TICKET_ID>/comments ^
+  -H "Authorization: Bearer <JWT>" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"body\":\"Looks good\"}"
+```
+
+### Verify Day 8 Attachments
+
+```bash
+# Presign upload
+curl.exe -i -X POST http://localhost:8080/tickets/<TICKET_ID>/attachments/presign-upload ^
+  -H "Authorization: Bearer <JWT>" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"fileName\":\"log.txt\",\"contentType\":\"text/plain\",\"fileSize\":12}"
+
+# Confirm upload
+curl.exe -i -X POST http://localhost:8080/tickets/<TICKET_ID>/attachments/<ATTACHMENT_ID>/confirm ^
+  -H "Authorization: Bearer <JWT>"
+
+# Presign download
+curl.exe -i -X GET http://localhost:8080/tickets/<TICKET_ID>/attachments/<ATTACHMENT_ID>/presign-download ^
+  -H "Authorization: Bearer <JWT>"
+```
+
+### Verify Day 8 Testcontainers (optional)
+
+```bash
+cd backend
+./mvnw test -Dtest=TicketCommentsTcIntegrationTest -DrunTestcontainers=true
+./mvnw test -Dtest=TicketAttachmentsTcIntegrationTest -DrunTestcontainers=true
+```
+
 ## Troubleshooting
 
 ### Port 5432 is already in use


### PR DESCRIPTION
## What
- Add ticket comments and attachments APIs with S3 presigned upload/download
- Add attachment metadata + presign service with tenant isolation
- Add Testcontainers coverage for comments/attachments
- Update OpenAPI, runbook, ADR, and AI log

## Why
- Deliver Day8: comments + attachments with presigned URLs
- Ensure tenant isolation and presign flows are validated

## How
- TicketComment/TicketAttachment entities + repos + services + controllers
- S3Presigner (AWS SDK v2) with short-lived URLs
- Mocked presigner in tests to avoid AWS calls
- TC tests gated by `-DrunTestcontainers=true`

## Testing
- `.\mvnw.cmd test`
- (Optional) `.\mvnw.cmd test -Dtest=TicketCommentsTcIntegrationTest -DrunTestcontainers=true`
- (Optional) `.\mvnw.cmd test -Dtest=TicketAttachmentsTcIntegrationTest -DrunTestcontainers=true`

## Risks
- Testcontainers requires Docker when enabled
- Presign URLs are short-lived; client must upload/confirm promptly