### PR TITLE
fix: Add Cognito mock to IntegrationTest to fix CI failures

### DIFF
--- a/backend/src/test/java/com/jiralite/backend/IntegrationTest.java
+++ b/backend/src/test/java/com/jiralite/backend/IntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jiralite.backend.config.TestCognitoConfig;
 import com.jiralite.backend.security.TestJwtDecoderConfig;
 
 /**
@@ -23,7 +24,7 @@ import com.jiralite.backend.security.TestJwtDecoderConfig;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-@Import(TestJwtDecoderConfig.class)
+@Import({ TestJwtDecoderConfig.class, TestCognitoConfig.class })
 class IntegrationTest {
 
     @Autowired

--- a/backend/src/test/java/com/jiralite/backend/config/TestCognitoConfig.java
+++ b/backend/src/test/java/com/jiralite/backend/config/TestCognitoConfig.java
@@ -1,0 +1,22 @@
+package com.jiralite.backend.config;
+
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+
+/**
+ * Test configuration that provides a mock CognitoIdentityProviderClient.
+ * This prevents tests from requiring actual AWS credentials.
+ */
+@TestConfiguration
+public class TestCognitoConfig {
+
+    @Bean
+    @Primary
+    public CognitoIdentityProviderClient cognitoClient() {
+        return Mockito.mock(CognitoIdentityProviderClient.class);
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -11,3 +11,10 @@ app:
     region: ap-southeast-2
     upload-expiry-seconds: 300
     download-expiry-seconds: 300
+  frontend:
+    url: http://localhost:5173
+
+aws:
+  region: ap-southeast-2
+  cognito:
+    user-pool-id: test-pool-id


### PR DESCRIPTION
## What
Fix CI/CD test failures by adding Cognito mock configuration.

## Why
After merging the Day 11 onboarding features, the backend tests failed (56 errors) because [OnboardingService](cci:2://file:///d:/coding/java_pro/jira-lite/backend/src/main/java/com/jiralite/backend/service/OnboardingService.java:31:0-143:1) requires a `CognitoIdentityProviderClient` bean, which was missing in the test context.

## How
- Created [TestCognitoConfig.java](cci:7://file:///d:/coding/java_pro/jira-lite/backend/src/test/java/com/jiralite/backend/config/TestCognitoConfig.java:0:0-0:0) to provide a mock `CognitoIdentityProviderClient` bean.
- Updated [IntegrationTest.java](cci:7://file:///d:/coding/java_pro/jira-lite/backend/src/test/java/com/jiralite/backend/IntegrationTest.java:0:0-0:0) base class to import [TestCognitoConfig](cci:2://file:///d:/coding/java_pro/jira-lite/backend/src/test/java/com/jiralite/backend/config/TestCognitoConfig.java:13:0-21:1).
- Added required `aws.cognito` and `app.frontend` properties to [src/test/resources/application.yml](cci:7://file:///d:/coding/java_pro/jira-lite/backend/src/test/resources/application.yml:0:0-0:0).

## Testing
- [x] Manual verification: Ran `mvn test -Dtest=IntegrationTest` locally -> **Passed** (5/5 tests).
- [x] Manual verification: Ran full `mvn test` locally -> **Passed** (All 74 tests passed).
- [ ] CI Pipeline: Will be verified by this PR build.

## Risks
None. This is a test-only change and does not affect production code logic.