### PR TITLE
fix: invitation acceptance - add cognito_sub and role group

### DIFF
--- a/frontend/src/pages/AcceptInvitationPage.tsx
+++ b/frontend/src/pages/AcceptInvitationPage.tsx
@@ -5,6 +5,7 @@ import { useMutation } from "@tanstack/react-query";
 import { acceptInvitation } from "../api/onboarding";
 import Loading from "../components/Loading";
 import { useAuth } from "../auth/AuthContext";
+import { buildAuthorizeUrl } from "../auth/auth";
 
 export default function AcceptInvitationPage() {
     const [searchParams] = useSearchParams();
@@ -16,9 +17,10 @@ export default function AcceptInvitationPage() {
 
     const mutation = useMutation({
         mutationFn: (token: string) => acceptInvitation(token),
-        onSuccess: () => {
-            // Force token refresh by reloading
-            window.location.href = "/projects";
+        onSuccess: async () => {
+            // Force re-login to get fresh token with org_id and role claims
+            const url = await buildAuthorizeUrl();
+            window.location.assign(url);
         },
         onError: (error: any) => {
             setErrorMessage(error.response?.data?.message || "Failed to accept invitation");


### PR DESCRIPTION
## What
Complete implementation of user registration, organization creation, and member invitation workflows with proper Cognito integration.

## Changes

### Lambda (V2_0 Format)
- Updated Pre Token Generation Lambda to V2_0 format
- Injects `email`, `org_id`, `custom:org_id` into Access Token
- Injects role into `cognito:groups` for RBAC

### Backend
- **OnboardingService**: Added email fallback via `AdminGetUser`, explicit group assignment
- **InvitationService**: Added `setCognitoSub()` and [addUserToGroup()](cci:1://file:///d:/coding/java_pro/jira-lite/backend/src/main/java/com/jiralite/backend/service/OnboardingService.java:155:4-165:5) for proper Cognito integration

### Frontend  
- **ProjectsPage**: Added "Invite Members" button with modal
- **CreateOrganizationPage**: Force re-login after org creation
- **AcceptInvitationPage**: Force re-login after invitation acceptance

### IAM
- Added `AdminGetUser` and `AdminAddUserToGroup` permissions to EC2 role

## Manual Configuration Required
- Set Cognito Lambda trigger version to **V2_0** in AWS Console

## Testing
- [x] New user registration → Create organization → Success
- [x] Invite member → Invited user registers → Auto-join organization
- [x] Token contains `email`, `org_id`, `cognito:groups`
- [x] Projects/Tickets CRUD working for both ADMIN and MEMBER roles