### PR TITLE
fix: hide invite button for non-admin users

### DIFF
--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 import ErrorBanner from "../components/ErrorBanner";
 import Loading from "../components/Loading";
 import InviteMembersModal from "../components/InviteMembersModal";
+import { useAuth } from "../auth/AuthContext";
 import {
   useArchiveProject,
   useCreateProject,
@@ -27,6 +28,7 @@ import { useNavigate } from "react-router-dom";
 
 export default function ProjectsPage() {
   const navigate = useNavigate();
+  const { state: authState } = useAuth();
   const projectsQuery = useProjects();
   const createProject = useCreateProject();
   const archiveProject = useArchiveProject();
@@ -59,9 +61,11 @@ export default function ProjectsPage() {
           Projects
         </Typography>
         <Box sx={{ display: "flex", gap: 1 }}>
-          <Button variant="outlined" onClick={() => setInviteOpen(true)}>
-            Invite Members
-          </Button>
+          {authState.profile?.["cognito:groups"]?.includes("ADMIN") && (
+            <Button variant="outlined" onClick={() => setInviteOpen(true)}>
+              Invite Members
+            </Button>
+          )}
           <Button variant="contained" onClick={() => setOpen(true)}>
             New Project
           </Button>


### PR DESCRIPTION
## What
This PR fixes critical reliability issues in the user invitation flow and enhances security by restricting invitation capabilities. Specifically:
1. Implements a robust invitation token transport using the OAuth2 `state` parameter to survive redirects.
2. Unifies frontend storage usage (fixed `localStorage` vs `sessionStorage` mismatch).
3. Restricts the "Invite Members" button to users with the `ADMIN` role only.
4. Optimizes the acceptance flow by redirecting unauthenticated users directly to Cognito.

## Why
- **Invitation Failures**: Users were frequently redirected to the "Create Organization" page instead of joining the invited organization. This was caused by the invitation token being lost during the Cognito redirect loop, exacerbated by a storage mismatch (Sender used `localStorage`, Receiver checked `sessionStorage`).
- **Security Gap**: Regular `MEMBER` users could see the "Invite Members" button.
- **User Experience**: The previous flow involving an intermediate login page added unnecessary friction.

## How
1. **Frontend Authentication (`auth.ts`)**:
   - Updated `buildAuthorizeUrl` to support passing a `state` parameter.
   - Updated `LoginPage` to parse the `state` parameter from the URL callback.

2. **Invitation Acceptance (`AcceptInvitationPage.tsx`)**:
   - Modified logic to pass the `token` into the OAuth `state` parameter.
   - Changed direct redirection behavior to skip the local `/login` route.

3. **Login Callback (`LoginPage.tsx`)**:
   - Added logic to retrieve the token from the `state` parameter.
   - Fixed the storage check to look in `localStorage` instead of `sessionStorage`.

4. **UI Permissions (`ProjectsPage.tsx`)**:
   - Added a conditional check `authState.profile?.["cognito:groups"]?.includes("ADMIN")` to hide the invite button.

## Testing
- [x] **Invitation Flow (Incognito)**: Verified end-to-end flow. Admin generates link -> New user opens in Incognito -> Redirects to Cognito -> Logs in -> Redirects back -> System identifies token from `state` -> User added to org.
- [x] **Permissions**: Verified that users with `MEMBER` role cannot see the "Invite Members" button.
- [x] **Storage Fallback**: Verified `localStorage` fallback logic.

## Risks
- **Low**: The `state` parameter is a standard part of the OAuth2 protocol supported by Cognito.
- **Data Integrity**: Relies on consistent email/user mapping in DB and Cognito.