### PR TITLE
fix: hide 'New Project' for non-admin users

### DIFF
--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -66,9 +66,11 @@ export default function ProjectsPage() {
               Invite Members
             </Button>
           )}
-          <Button variant="contained" onClick={() => setOpen(true)}>
-            New Project
-          </Button>
+          {authState.profile?.["cognito:groups"]?.includes("ADMIN") && (
+            <Button variant="contained" onClick={() => setOpen(true)}>
+              New Project
+            </Button>
+          )}
         </Box>
       </Box>
 


### PR DESCRIPTION
## What
This PR restricts the visibility of the "New Project" button in the UI, ensuring only users with the `ADMIN` role can see and access it.

## Why
- **Security & RBAC Enforcement**: While the backend `ProjectsController` already enforces specific permissions (allowing only ADMINs to create projects), the frontend previously displayed the "New Project" button to all users.
- **User Experience**: Clicking the button as a non-admin would result in a 403 Forbidden error or failure, creating a confusing experience for MEMBER users. Hiding the button aligns the UI availability with the actual backend permissions.

## How
1. **Modules Modified**: `frontend/src/pages/ProjectsPage.tsx`
2. **Implementation**:
    - Added a conditional check using `authState.profile?.["cognito:groups"]?.includes("ADMIN")`.
    - Wrapped the "New Project" button component in this check so it only renders for authenticated users belonging to the `ADMIN` group.

## Testing
- [x] **Permissions Check**: Logged in as a user with the `MEMBER` role and verified that the "New Project" button is **not** visible.
- [x] **Admin Verification**: Logged in as a user with the `ADMIN` role and verified that the "New Project" button **is** visible and functional.

## Risks
- **Low**: This is a purely presentation-layer change that reflects existing backend rules. It depends on the `cognito:groups` claim being correctly populated in the user's ID token.
