### PR TITLE
feat(day12): add awslogs, budget alert, s3 delete, ticket reopen, jwt…

### DIFF
--- a/backend/src/main/java/com/jiralite/backend/config/S3Config.java
+++ b/backend/src/main/java/com/jiralite/backend/config/S3Config.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 /**
@@ -16,6 +17,13 @@ public class S3Config {
     @Bean
     public S3Presigner s3Presigner(@Value("${app.s3.region}") String region) {
         return S3Presigner.builder()
+                .region(Region.of(region))
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client(@Value("${app.s3.region}") String region) {
+        return S3Client.builder()
                 .region(Region.of(region))
                 .build();
     }

--- a/backend/src/main/java/com/jiralite/backend/service/TicketService.java
+++ b/backend/src/main/java/com/jiralite/backend/service/TicketService.java
@@ -225,7 +225,7 @@ public class TicketService {
         return switch (current) {
             case "OPEN" -> next.equals("IN_PROGRESS") || next.equals("DONE") || next.equals("CANCELLED");
             case "IN_PROGRESS" -> next.equals("DONE") || next.equals("CANCELLED");
-            case "DONE", "CANCELLED" -> false;
+            case "DONE", "CANCELLED" -> next.equals("OPEN") || next.equals("IN_PROGRESS");
             default -> false;
         };
     }

--- a/backend/src/test/java/com/jiralite/backend/integration/InvitationIntegrationTest.java
+++ b/backend/src/test/java/com/jiralite/backend/integration/InvitationIntegrationTest.java
@@ -1,0 +1,128 @@
+package com.jiralite.backend.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.jiralite.backend.config.TestCognitoConfig;
+import com.jiralite.backend.security.TestJwtDecoderConfig;
+import com.jiralite.backend.entity.InvitationEntity;
+import com.jiralite.backend.entity.OrgEntity;
+import com.jiralite.backend.entity.OrgMembershipEntity;
+import com.jiralite.backend.entity.OrgMembershipId;
+import com.jiralite.backend.entity.UserEntity;
+import com.jiralite.backend.repository.InvitationRepository;
+import com.jiralite.backend.repository.OrgMembershipRepository;
+import com.jiralite.backend.repository.OrgRepository;
+import com.jiralite.backend.repository.UserRepository;
+import com.jiralite.backend.service.InvitationService;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import({ TestCognitoConfig.class, TestJwtDecoderConfig.class })
+@Testcontainers
+@EnabledIfSystemProperty(named = "runTestcontainers", matches = "true")
+class InvitationIntegrationTest {
+
+    private static final UUID ORG_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID CREATOR_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID INVITEE_ID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final String INVITEE_EMAIL = "invitee@example.com";
+
+    @Container
+    private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
+            .withDatabaseName("jira_lite")
+            .withUsername("jira_lite")
+            .withPassword("jira_lite_password");
+
+    @DynamicPropertySource
+    static void configureDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+    }
+
+    @Autowired
+    private InvitationService invitationService;
+
+    @Autowired
+    private InvitationRepository invitationRepository;
+
+    @Autowired
+    private OrgRepository orgRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private OrgMembershipRepository membershipRepository;
+
+    @BeforeEach
+    void setUp() {
+        membershipRepository.deleteAll();
+        invitationRepository.deleteAll();
+        userRepository.deleteAll();
+        orgRepository.deleteAll();
+
+        OrgEntity org = new OrgEntity();
+        org.setId(ORG_ID);
+        org.setName("Test Org");
+        org.setCreatedAt(OffsetDateTime.now());
+        org.setUpdatedAt(OffsetDateTime.now());
+        orgRepository.save(org);
+
+        UserEntity creator = new UserEntity();
+        creator.setId(CREATOR_ID);
+        creator.setEmail("creator@example.com");
+        creator.setCognitoSub(CREATOR_ID.toString());
+        creator.setCreatedAt(OffsetDateTime.now());
+        creator.setUpdatedAt(OffsetDateTime.now());
+        userRepository.save(creator);
+
+        OrgMembershipEntity adminMembership = new OrgMembershipEntity();
+        adminMembership.setId(new OrgMembershipId(ORG_ID, CREATOR_ID));
+        adminMembership.setRole("ADMIN");
+        adminMembership.setStatus("ACTIVE");
+        adminMembership.setCreatedAt(OffsetDateTime.now());
+        adminMembership.setUpdatedAt(OffsetDateTime.now());
+        membershipRepository.save(adminMembership);
+    }
+
+    @Test
+    void invitationFlowCreatesUserAndMembership() {
+        String token = invitationService.createInvitation(ORG_ID, INVITEE_EMAIL, "MEMBER", CREATOR_ID);
+
+        InvitationEntity invitation = invitationRepository.findByToken(token).orElseThrow();
+        assertThat(invitation.getOrgId()).isEqualTo(ORG_ID);
+        assertThat(invitation.getEmail()).isEqualTo(INVITEE_EMAIL);
+
+        invitationService.acceptInvitation(token, INVITEE_ID, INVITEE_EMAIL);
+
+        UserEntity invitee = userRepository.findById(INVITEE_ID).orElseThrow();
+        assertThat(invitee.getEmail()).isEqualTo(INVITEE_EMAIL);
+        assertThat(invitee.getCognitoSub()).isEqualTo(INVITEE_ID.toString());
+
+        OrgMembershipEntity membership = membershipRepository.findById(new OrgMembershipId(ORG_ID, INVITEE_ID))
+                .orElseThrow();
+        assertThat(membership.getRole()).isEqualTo("MEMBER");
+        assertThat(membership.getStatus()).isEqualTo("ACTIVE");
+
+        assertThat(invitationRepository.findByToken(token)).isEmpty();
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^5.15.20",
         "@mui/material": "^5.15.20",
         "@tanstack/react-query": "^5.59.0",
+        "jwt-decode": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2"
@@ -1865,6 +1866,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/lines-and-columns": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@mui/icons-material": "^5.15.20",
     "@mui/material": "^5.15.20",
     "@tanstack/react-query": "^5.59.0",
+    "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2"

--- a/frontend/src/auth/auth.ts
+++ b/frontend/src/auth/auth.ts
@@ -1,3 +1,4 @@
+import { jwtDecode } from "jwt-decode";
 import { generateChallenge, generateVerifier } from "./pkce";
 import { AuthTokens } from "./storage";
 
@@ -92,14 +93,8 @@ export type JwtProfile = {
 };
 
 export function decodeJwt(token: string): JwtProfile {
-  const parts = token.split(".");
-  if (parts.length < 2) {
-    return {};
-  }
-  const payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-  const decoded = atob(payload + "==".slice((payload.length + 2) % 4));
   try {
-    return JSON.parse(decoded) as JwtProfile;
+    return jwtDecode<JwtProfile>(token);
   } catch {
     return {};
   }

--- a/frontend/src/components/InviteMembersModal.tsx
+++ b/frontend/src/components/InviteMembersModal.tsx
@@ -21,6 +21,7 @@ import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { createInvitation, CreateInvitationResponse } from "../api/onboarding";
 import { useAuth } from "../auth/AuthContext";
+import { useNotify } from "./Notifications";
 
 interface InviteMembersModalProps {
     open: boolean;
@@ -31,6 +32,7 @@ export default function InviteMembersModal({ open, onClose }: InviteMembersModal
     const [email, setEmail] = useState("");
     const [role, setRole] = useState("MEMBER");
     const { state } = useAuth();
+    const { notifySuccess } = useNotify();
 
     const orgId = (state.profile as any)?.["custom:org_id"];
 
@@ -38,6 +40,7 @@ export default function InviteMembersModal({ open, onClose }: InviteMembersModal
         mutationFn: () => createInvitation(orgId, { email, role }),
         onSuccess: () => {
             // Don't reset form or close modal - show success with invitation link
+            notifySuccess("邀请已发送");
         },
     });
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -107,3 +107,12 @@ module "cloudwatch" {
   environment  = var.environment
   ec2_instance_id = module.compute.instance_id
 }
+
+# Budgets Module
+module "budgets" {
+  source = "./modules/budgets"
+
+  project_name = var.project_name
+  environment  = var.environment
+  alert_email  = var.alert_email
+}

--- a/infra/terraform/modules/budgets/main.tf
+++ b/infra/terraform/modules/budgets/main.tf
@@ -1,0 +1,30 @@
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "alert_email" {
+  description = "Email address for budget alerts"
+  type        = string
+}
+
+resource "aws_budgets_budget" "monthly" {
+  name         = "${var.project_name}-${var.environment}-monthly-budget"
+  budget_type  = "COST"
+  limit_amount = "5"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.alert_email]
+  }
+}

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -69,6 +69,9 @@ systemctl start docker
 systemctl enable docker
 usermod -aG docker ec2-user
 
+# Install CloudWatch Agent (for future extensions/metrics)
+yum install -y amazon-cloudwatch-agent
+
 # Install Docker Compose
 curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
@@ -131,6 +134,10 @@ docker run -d \
   --name jira-backend \
   --restart unless-stopped \
   -p 8080:8080 \
+  --log-driver=awslogs \
+  --log-opt awslogs-region=ap-southeast-2 \
+  --log-opt awslogs-group=/aws/ec2/${var.project_name}-${var.environment}-backend \
+  --log-opt awslogs-stream=jira-backend \
   --env-file /home/ec2-user/.env \
   ${var.ecr_repository_url}:latest
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -125,3 +125,8 @@ variable "github_repo" {
   description = "GitHub repository name"
   type        = string
 }
+
+variable "alert_email" {
+  description = "Email address for billing alerts"
+  type        = string
+}


### PR DESCRIPTION
## What
- Add awslogs logging to backend EC2 container and enable CloudWatch log streaming.
- Introduce monthly $5 AWS Budget with 80% email alert.
- Delete S3 objects when attachments are removed; add S3Client support.
- Allow tickets to reopen from DONE/CANCELLED to OPEN/IN_PROGRESS; add invitation integration test (Testcontainers).
- Frontend: use jwt-decode for token parsing; show success toast on invitations.

## Why
- Improve observability and cost governance for prod.
- Prevent orphaned S3 objects and allow ticket reopen workflow.
- Harden auth/UX by reliable JWT decoding and clear user feedback.

## How
- Terraform: update compute user_data for awslogs, add budgets module, set alert_email; IAM already allows logs/S3 delete.
- Backend: inject S3Client + deleteObject; TicketAttachmentService best-effort S3 delete; relax TicketService transitions; add InvitationIntegrationTest with Testcontainers.
- Frontend: add jwt-decode dep; replace manual atob decode; invite modal fires success toast.

## Testing
- Terraform: `terraform plan/apply` (applied).
- Backend: `mvn test` (TC tests require Docker: `-DrunTestcontainers=true`).
- Frontend: `npm install && npm run build`.
- Manual: attachment delete removes S3 object; DONE/CANCELLED → OPEN/IN_PROGRESS works; CloudWatch log stream under `/aws/ec2/jira-lite-prod-backend`.

## Risks
- Testcontainers fail locally without Docker (skip or enable daemon).
- CloudWatch log shipping depends on awslogs config; verify after deploy.
- Budget emails require correct alert_email and SNS/Email deliverability.