### PR TITLE
fix(backend): prevent ticket save failure for long AI-generated text

### DIFF
--- a/backend/src/main/java/com/jiralite/backend/entity/AuditLogEntity.java
+++ b/backend/src/main/java/com/jiralite/backend/entity/AuditLogEntity.java
@@ -30,7 +30,7 @@ public class AuditLogEntity {
     @Column(name = "entity_id")
     private String entityId;
 
-    @Column
+    @Column(columnDefinition = "TEXT")
     private String details;
 
     @Column(name = "created_at", nullable = false)

--- a/backend/src/main/java/com/jiralite/backend/entity/NotificationEntity.java
+++ b/backend/src/main/java/com/jiralite/backend/entity/NotificationEntity.java
@@ -24,7 +24,7 @@ public class NotificationEntity {
     @Column(nullable = false)
     private String type;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(name = "is_read", nullable = false)

--- a/backend/src/main/java/com/jiralite/backend/entity/ProjectEntity.java
+++ b/backend/src/main/java/com/jiralite/backend/entity/ProjectEntity.java
@@ -27,7 +27,7 @@ public class ProjectEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/jiralite/backend/entity/TicketCommentEntity.java
+++ b/backend/src/main/java/com/jiralite/backend/entity/TicketCommentEntity.java
@@ -27,7 +27,7 @@ public class TicketCommentEntity {
     @Column(name = "author_id")
     private UUID authorId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String body;
 
     @Column(name = "created_at", nullable = false)

--- a/backend/src/main/java/com/jiralite/backend/entity/TicketEntity.java
+++ b/backend/src/main/java/com/jiralite/backend/entity/TicketEntity.java
@@ -30,7 +30,7 @@ public class TicketEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     @Column(nullable = false)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       write-dates-as-timestamps: false
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: false
     properties:
       hibernate:

--- a/backend/src/main/resources/db/migration/V13__normalize_text_columns.sql
+++ b/backend/src/main/resources/db/migration/V13__normalize_text_columns.sql
@@ -1,0 +1,20 @@
+-- V13: Normalize long text columns to TEXT to prevent varchar(255) truncation errors
+
+BEGIN;
+
+ALTER TABLE tickets
+  ALTER COLUMN description TYPE TEXT;
+
+ALTER TABLE projects
+  ALTER COLUMN description TYPE TEXT;
+
+ALTER TABLE ticket_comments
+  ALTER COLUMN body TYPE TEXT;
+
+ALTER TABLE notifications
+  ALTER COLUMN content TYPE TEXT;
+
+ALTER TABLE audit_logs
+  ALTER COLUMN details TYPE TEXT;
+
+COMMIT;


### PR DESCRIPTION
## What
- Improved backend AI polish handling (better error mapping and model fallback).
- Added production AI env wiring in Terraform (`AI_GEMINI_API_KEY`, `AI_GEMINI_MODEL`).
- Fixed save failures for long AI-generated text by normalizing key DB columns to `TEXT` (Flyway `V13`).
- Reduced frontend build warnings and initial bundle size (lazy-loaded routes, cleaned imports).

## Why
- AI polish failed in production due to provider/config issues.
- Production env did not consistently inject Gemini config.
- Ticket save failed when generated description exceeded `varchar(255)`.

## How
- Updated `AiService` and backend config defaults.
- Extended Terraform compute module env template and variables.
- Added Flyway migration to enforce `TEXT` for long-content fields.
- Updated frontend routing/import strategy.

## Testing
- Backend: `mvn -Dtest=AiServiceTest test`
- Backend compile: `mvn "-DskipTests" "-Dmaven.compiler.useIncrementalCompilation=false" compile`
- Frontend: `npm run build`

## Risks
- Terraform rollout may require instance reprovisioning for env updates.
- External Gemini quota limits (429) can still impact AI polish.